### PR TITLE
Removed limit on table listing completely

### DIFF
--- a/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
@@ -391,8 +391,9 @@ public class BQSupportFuncts {
                 ", datasetID:" + (datasetId != null ? datasetId : "null") +
                 "connection");
         projectId = projectId.replace("__", ":").replace("_", ".");
-        List<Tables> tables = connection.getBigquery().tables()
-                .list(projectId, datasetId).execute().getTables();
+        Bigquery.Tables.List listCall = connection.getBigquery().tables()
+                .list(projectId, datasetId).setMaxResults(10000000L);  // Really big number that we'll never hit
+        List<Tables> tables = listCall.execute().getTables();
         if (tables != null && tables.size() != 0) {
             if (tableNamePattern != null) {
                 List<Tables> tablesSearch = new ArrayList<Tables>();


### PR DESCRIPTION
Made number very very very large. Turns out there is a way to scroll through the results from the API, but that would require rewriting a very significant chunk of the driver. I'm going to switch BigQuery's `information_schema` off JDBC soon enough, but this should tide us over until we get there. 

If this seems too objectionable, then I'll just block bigquery PDTs on rewriting the information schema. What do you think?