### PR TITLE
Query cancel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>1.19.0</version>
+      <version>1.20.0</version>
     </dependency>
     <dependency>
       <groupId>org.mortbay.jetty</groupId>
@@ -49,12 +49,12 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-jackson</artifactId>
-      <version>1.19.0</version>
+      <version>1.20.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-bigquery</artifactId>
-      <version>v2-rev157-1.19.0</version>
+      <version>v2-rev240-1.20.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
@@ -34,10 +34,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.security.GeneralSecurityException;
 import java.sql.*;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -68,6 +65,8 @@ public class BQConnection implements Connection {
     private String projectId = null;
     /** Boolean to determine if the Connection is closed */
     private boolean isclosed = false;
+
+    private final Set<BQStatementRoot> runningStatements = Collections.synchronizedSet(new HashSet<BQStatementRoot>());
 
     /** Boolean to determine, to use or doesn't use the ANTLR parser */
     private boolean transformQuery = false;
@@ -238,6 +237,7 @@ public class BQConnection implements Connection {
     @Override
     public void close() throws SQLException {
         if (!this.isclosed) {
+            this.cancelRunningQueries();
             this.bigquery = null;
             this.isclosed = true;
         }
@@ -974,4 +974,29 @@ public class BQConnection implements Connection {
         throw new BQSQLException("Not found");
     }
 
+    public void addRunningStatement(BQStatementRoot stmt) {
+        this.runningStatements.add(stmt);
+    }
+
+    public void removeRunningStatement(BQStatementRoot stmt) {
+        this.runningStatements.remove(stmt);
+    }
+
+    public int getNumberRunningQueries() {
+        return this.runningStatements.size();
+    }
+
+    public int cancelRunningQueries() {
+        int numFailed = 0;
+        synchronized (this.runningStatements) {
+            for(BQStatementRoot stmt : this.runningStatements) {
+                try {
+                    stmt.cancel();
+                } catch (SQLException e) {
+                    numFailed++;
+                }
+            }
+        }
+        return numFailed;
+    }
 }

--- a/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
@@ -37,6 +37,7 @@ import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
+import java.util.UUID;
 
 import com.google.api.services.bigquery.model.*;
 import org.apache.log4j.Logger;
@@ -357,6 +358,17 @@ public class BQSupportFuncts {
     }
 
     /**
+     * Cancels a job. Uses the fact that it returns a JobCancelResponse to help enforce actually calling .execute().
+     *
+     * @param job     Instance of Job
+     * @param bigquery  Instance of authorized Bigquery client
+     * @param projectId The id of the Project the job is contained in
+     */
+    public static JobCancelResponse cancelQuery(Job job, Bigquery bigquery, String projectId) throws IOException {
+        return bigquery.jobs().cancel(projectId, job.getJobReference().getJobId()).execute();
+    }
+
+    /**
      * Parses a (instance of table).getid() and gives back the id only for the
      * table
      *
@@ -602,6 +614,10 @@ public class BQSupportFuncts {
         JobConfiguration config = new JobConfiguration();
         JobConfigurationQuery queryConfig = new JobConfigurationQuery();
         config.setQuery(queryConfig);
+
+        JobReference jobReference = new JobReference().setProjectId(projectId).setJobId(UUID.randomUUID().toString().replace("-", ""));
+        job.setJobReference(jobReference);
+
         if (dataSet != null)
             queryConfig.setDefaultDataset(new DatasetReference().setDatasetId(dataSet).setProjectId(projectId));
 

--- a/src/test/java/BQJDBC/QueryResultTest/CancelTest.java
+++ b/src/test/java/BQJDBC/QueryResultTest/CancelTest.java
@@ -1,0 +1,133 @@
+package BQJDBC.QueryResultTest;
+
+import com.google.api.services.bigquery.model.Job;
+import net.starschema.clouddb.jdbc.BQConnection;
+import net.starschema.clouddb.jdbc.BQStatement;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Properties;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+
+/**
+ * Created by steven on 11/2/15.
+ */
+public class CancelTest {
+
+    static final String URL = "jdbc:BQDriver::disco-parsec-659/looker_test?withServiceAccount=true&user=697117590302-76cr6q3217nck6gks0kf4r151j4d9f8e@developer.gserviceaccount.com&password=src%2F%2Ftest%2Fresources%2Fbigquery_credentials.p12";
+    private BQConnection bq;
+
+    @Before
+    public void setup() throws SQLException {
+        this.bq = new BQConnection(URL, new Properties());
+    }
+
+    private Thread getAndRunBackgroundQuery(final BQStatement stmt) {
+        Runnable background = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    stmt.executeQuery("select * from publicdata:samples.shakespeare limit 712");
+                } catch (SQLException e) {}
+            }
+        };
+        Thread backgroundThread = new Thread(background);
+        backgroundThread.start();
+        return backgroundThread;
+    }
+
+    @org.junit.Test
+    public void cancelWorks() throws SQLException, InterruptedException, IOException {
+        TestableBQStatement stmt = new TestableBQStatement(bq.getProjectId(), bq);
+        stmt.setTestPoint();
+
+        Thread backgroundThread = getAndRunBackgroundQuery(stmt);
+
+        stmt.waitForTestPoint();
+        assertFalse("Statement must have job", stmt.getJob() == null);
+
+        // This will throw error if it tries to cancel a nonexistent job
+        stmt.cancel();
+
+        backgroundThread.join();
+
+        // TODO: better checks that cancel worked
+        // Right now, there seems to be no reliable indication in the API that a job was cancelled (status is always 'DONE'),
+        // and even if the cancel signal was received the result is likely to come back successfully with all its rows.
+        // If the Google folks change the API to add a status like 'CANCEL_RECEIVED', we should check for that here
+    }
+
+    @org.junit.Test
+    public void connectionCancelWorks() throws InterruptedException {
+        final TestableBQStatement stmt1 = new TestableBQStatement(bq.getProjectId(), bq);
+        final TestableBQStatement stmt2 = new TestableBQStatement(bq.getProjectId(), bq);
+
+        stmt1.setTestPoint();
+        stmt2.setTestPoint();
+
+        Thread backgroundThread1 = getAndRunBackgroundQuery(stmt1);
+        Thread backgroundThread2 = getAndRunBackgroundQuery(stmt2);
+
+        stmt1.waitForTestPoint();
+        stmt2.waitForTestPoint();
+
+        assertTrue("Must see both running queries", bq.getNumberRunningQueries() == 2);
+        assertTrue("Must not fail to cancel queries", bq.cancelRunningQueries() == 0);
+
+        backgroundThread1.join();
+        backgroundThread2.join();
+    }
+
+    private static class TestableBQStatement extends BQStatement {
+
+        public TestableBQStatement(String projectid, BQConnection bqConnection) {
+            super(projectid, bqConnection);
+        }
+
+        private Condition testPoint;
+        private Lock testLock;
+        private boolean conditionHit = false;
+
+        private void signalTestPoint() {
+            if (this.testPoint == null) {
+                return;
+            }
+            this.testLock.lock();
+            try {
+                conditionHit = true;
+                this.testPoint.signal();
+            } finally {
+                this.testLock.unlock();
+            }
+        }
+
+        public void setTestPoint() {
+            Lock lock = new ReentrantLock();
+            this.testPoint = lock.newCondition();
+            this.testLock = lock;
+        }
+
+        public void waitForTestPoint() throws InterruptedException {
+            this.testLock.lock();
+            try {
+                if (!conditionHit) {
+                    this.testPoint.await();
+                }
+            } finally {
+                this.testLock.unlock();
+            }
+        }
+
+        public Job startQuery(String querySql) throws IOException {
+            Job result = super.startQuery(querySql);
+            signalTestPoint();
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
Threw in the ability for a BQConnection to cancel all of its current queries. This shouldn't affect anything for anyone not using cancel().