### PR TITLE
Add the ability to set the read/connect timeout 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,5 +149,5 @@
     </plugins>
     <finalName>${project.artifactId}-${project.version}-thin</finalName>
   </build>
-  <version>1.6.0</version>
+  <version>1.6.1</version>
 </project>

--- a/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
@@ -159,6 +159,32 @@ public class BQConnection implements Connection {
         String legacySqlParam = caseInsensitiveProps.getProperty("uselegacysql");
         this.useLegacySql = (legacySqlParam == null) || Boolean.parseBoolean(legacySqlParam);
 
+        String readTimeoutString = caseInsensitiveProps.getProperty("readtimeout");
+        Integer readTimeout = null;
+        if (readTimeoutString != null) {
+            try {
+                readTimeout = Integer.parseInt(readTimeoutString);
+                if (readTimeout < 0) {
+                    throw new BQSQLException("readTimeout must be positive.");
+                }
+            } catch (NumberFormatException e) {
+                throw new BQSQLException("could not parse readTimeout parameter.", e);
+            }
+        }
+
+        String connectTimeoutString = caseInsensitiveProps.getProperty("connecttimeout");
+        Integer connectTimeout = null;
+        if (connectTimeoutString != null) {
+            try {
+                connectTimeout = Integer.parseInt(connectTimeoutString);
+                if (connectTimeout < 0) {
+                    throw new BQSQLException("connectTimeout must be positive.");
+                }
+            } catch (NumberFormatException e) {
+                throw new BQSQLException("could not parse connectTimeout parameter.", e);
+            }
+        }
+
         // extract UA String
         String userAgent = caseInsensitiveProps.getProperty("useragent");
 
@@ -170,7 +196,7 @@ public class BQConnection implements Connection {
                     userPath = userKey;
                     userKey = null;
                 }
-                this.bigquery = Oauth2Bigquery.authorizeviaservice(userId, userPath, userKey, userAgent);
+                this.bigquery = Oauth2Bigquery.authorizeviaservice(userId, userPath, userKey, userAgent, connectTimeout, readTimeout);
                 this.logger.info("Authorized with service account");
             } catch (GeneralSecurityException e) {
                 throw new BQSQLException(e);

--- a/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
@@ -29,6 +29,7 @@
 
 package net.starschema.clouddb.jdbc;
 
+import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.services.bigquery.Bigquery;
 import com.google.api.services.bigquery.Bigquery.Jobs.Insert;
 import com.google.api.services.bigquery.model.DatasetList.Datasets;
@@ -646,15 +647,14 @@ public class BQSupportFuncts {
      */
     public static Job startQuery(Bigquery bigquery, String projectId,
                                  String querySql, String dataSet, Boolean useLegacySql) throws IOException {
-        BQSupportFuncts.logger.info("Inserting Query Job: " + querySql.replace("\t", "").replace("\n", " ").replace("\r", ""));
         projectId = projectId.replace("__", ":").replace("_", ".");
         Job job = new Job();
         JobConfiguration config = new JobConfiguration();
         JobConfigurationQuery queryConfig = new JobConfigurationQuery();
         queryConfig.setUseLegacySql(useLegacySql);
         config.setQuery(queryConfig);
-
-        JobReference jobReference = new JobReference().setProjectId(projectId).setJobId(UUID.randomUUID().toString().replace("-", ""));
+        String jobId = UUID.randomUUID().toString().replace("-", "");
+        JobReference jobReference = new JobReference().setProjectId(projectId).setJobId(jobId);
         job.setJobReference(jobReference);
 
         if (dataSet != null)
@@ -665,6 +665,7 @@ public class BQSupportFuncts {
 
         Insert insert = bigquery.jobs().insert(querySql, job);
         insert.setProjectId(projectId);
+        BQSupportFuncts.logger.info("Inserting Query Job (" + jobId + "): " + querySql.replace("\t", "").replace("\n", " ").replace("\r", ""));
         return insert.execute();
     }
 

--- a/src/test/java/BQJDBC/QueryResultTest/JdbcUrlTest.java
+++ b/src/test/java/BQJDBC/QueryResultTest/JdbcUrlTest.java
@@ -34,6 +34,37 @@ public class JdbcUrlTest {
     }
 
     @Test
+    public void urlWithTimeouts() throws SQLException {
+        try {
+            String url1 = URL + "&readTimeout=foo";
+            new BQConnection(url1, new Properties());
+        } catch (SQLException e){
+            Assert.assertEquals("could not parse readTimeout parameter.", e.getMessage());
+        }
+
+        try {
+            String url1 = URL + "&connectTimeout=foo";
+            new BQConnection(url1, new Properties());
+        } catch (SQLException e){
+            Assert.assertEquals("could not parse connectTimeout parameter.", e.getMessage());
+        }
+
+        try {
+            String url1 = URL + "&readTimeout=-1000";
+            new BQConnection(url1, new Properties());
+        } catch (SQLException e){
+            Assert.assertEquals("readTimeout must be positive.", e.getMessage());
+        }
+
+        try {
+            String url1 = URL + "&connectTimeout=-1000";
+            new BQConnection(url1, new Properties());
+        } catch (SQLException e){
+            Assert.assertEquals("connectTimeout must be positive.", e.getMessage());
+        }
+    }
+
+    @Test
     public void canRunQueryWithDefaultDataset() throws SQLException {
         BQStatement stmt = new BQStatement(properties.getProperty("projectid"), bq);
 


### PR DESCRIPTION
The default value is still the same for both (20s), but can now be configured by specifying the readTimeout/connectTimeout parameters in the JDBC url / connection properties.