### PR TITLE
Add some resiliency to the API interactions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,5 +149,5 @@
     </plugins>
     <finalName>${project.artifactId}-${project.version}-thin</finalName>
   </build>
-  <version>1.8.7</version>
+  <version>1.8.8</version>
 </project>

--- a/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
@@ -93,12 +93,6 @@ public class BQConnection implements Connection {
     /** String to contain the url except the url prefix */
     private String URLPART = null;
 
-    /** Though the default in the BigQuery API client is 20s, BigQuery claims the timeout on their
-     * backend is actually 240s. Make that the default going forward to minimize compatibility issues.
-     * */
-    private static int DEFAULT_READ_TIMEOUT = 240000;
-    private static int DEFAULT_CONNECT_TIMEOUT = 240000;
-
     /**
      * Extracts the JDBC URL then makes a connection to the Bigquery.
      *
@@ -169,7 +163,7 @@ public class BQConnection implements Connection {
         this.useLegacySql = (legacySqlParam == null) || Boolean.parseBoolean(legacySqlParam);
 
         String readTimeoutString = caseInsensitiveProps.getProperty("readtimeout");
-        Integer readTimeout = DEFAULT_READ_TIMEOUT;
+        Integer readTimeout = null;
         if (readTimeoutString != null) {
             try {
                 readTimeout = Integer.parseInt(readTimeoutString);
@@ -182,7 +176,7 @@ public class BQConnection implements Connection {
         }
 
         String connectTimeoutString = caseInsensitiveProps.getProperty("connecttimeout");
-        Integer connectTimeout = DEFAULT_CONNECT_TIMEOUT;
+        Integer connectTimeout = null;
         if (connectTimeoutString != null) {
             try {
                 connectTimeout = Integer.parseInt(connectTimeoutString);

--- a/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
@@ -93,6 +93,12 @@ public class BQConnection implements Connection {
     /** String to contain the url except the url prefix */
     private String URLPART = null;
 
+    /** Though the default in the BigQuery API client is 20s, BigQuery claims the timeout on their
+     * backend is actually 240s. Make that the default going forward to minimize compatibility issues.
+     * */
+    private static int DEFAULT_READ_TIMEOUT = 240000;
+    private static int DEFAULT_CONNECT_TIMEOUT = 240000;
+
     /**
      * Extracts the JDBC URL then makes a connection to the Bigquery.
      *
@@ -163,7 +169,7 @@ public class BQConnection implements Connection {
         this.useLegacySql = (legacySqlParam == null) || Boolean.parseBoolean(legacySqlParam);
 
         String readTimeoutString = caseInsensitiveProps.getProperty("readtimeout");
-        Integer readTimeout = null;
+        Integer readTimeout = DEFAULT_READ_TIMEOUT;
         if (readTimeoutString != null) {
             try {
                 readTimeout = Integer.parseInt(readTimeoutString);
@@ -176,7 +182,7 @@ public class BQConnection implements Connection {
         }
 
         String connectTimeoutString = caseInsensitiveProps.getProperty("connecttimeout");
-        Integer connectTimeout = null;
+        Integer connectTimeout = DEFAULT_CONNECT_TIMEOUT;
         if (connectTimeoutString != null) {
             try {
                 connectTimeout = Integer.parseInt(connectTimeoutString);

--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
@@ -115,7 +115,7 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
             // Gets the Job reference of the completed job with give Query
             referencedJob = startQuery(querySql);
         } catch (IOException e) {
-            throw new BQSQLException("Something went wrong with the query: " + querySql, e);
+            throw new BQSQLException("Something went wrong creating the query: " + querySql, e);
         }
         try {
             do {
@@ -150,7 +150,9 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
             while (System.currentTimeMillis() - this.starttime <= (long) this.querytimeout * 1000);
             // it runs for a minimum of 1 time
         } catch (IOException e) {
-            throw new BQSQLException("Something went wrong with the query: " + querySql, e);
+            throw new BQSQLException(
+                    "Something went wrong getting results for the job " + referencedJob.getId() + ", query: " + querySql,
+                    e);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
1. Bump default timeout to 240s, which according to Google is the timeout on their backend.
1. Make sure the job id shows up the error message we throw when the result fetch fails.
1. Add some retries into our result fetch.