### PR TITLE
Don't explode when you get an array or hash

### DIFF
--- a/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
@@ -27,6 +27,8 @@
 
 package net.starschema.clouddb.jdbc;
 
+import com.google.api.client.json.JsonGenerator;
+import com.google.api.client.json.jackson.JacksonFactory;
 import com.google.api.client.util.Data;
 import com.google.api.services.bigquery.Bigquery;
 import com.google.api.services.bigquery.model.GetQueryResultsResponse;
@@ -42,6 +44,7 @@ import java.net.URL;
 import java.sql.*;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -271,6 +274,19 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
             return null;
         }
         this.wasnull = false;
+        if (resultObject instanceof List || resultObject instanceof Map) {
+            Writer writer = new StringWriter();
+            try {
+                JsonGenerator gen = new JacksonFactory().createJsonGenerator(writer);
+                gen.serialize(resultObject);
+                gen.close();
+            } catch (IOException e) {
+                // Um, a string writer is not going to throw an IO exception, but fine.
+                throw new SQLException("Failed to write JSON", e);
+            }
+            resultObject = writer.toString();
+
+        }
         return (String) resultObject;
     }
 

--- a/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
@@ -33,6 +33,7 @@ import com.google.api.client.util.Data;
 import com.google.api.services.bigquery.Bigquery;
 import com.google.api.services.bigquery.model.GetQueryResultsResponse;
 import com.google.api.services.bigquery.model.Job;
+import com.google.api.services.bigquery.model.TableFieldSchema;
 import com.google.api.services.bigquery.model.TableRow;
 import org.apache.log4j.Logger;
 
@@ -42,11 +43,9 @@ import java.math.BigInteger;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.sql.*;
+import java.sql.Date;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.List;
-import java.util.Map;
-import java.util.TimeZone;
+import java.util.*;
 
 /**
  * This class implements the java.sql.ResultSet interface, as a Forward only resultset
@@ -275,19 +274,63 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
         }
         this.wasnull = false;
         if (resultObject instanceof List || resultObject instanceof Map) {
-            Writer writer = new StringWriter();
-            try {
-                JsonGenerator gen = new JacksonFactory().createJsonGenerator(writer);
-                gen.serialize(resultObject);
-                gen.close();
-            } catch (IOException e) {
-                // Um, a string writer is not going to throw an IO exception, but fine.
-                throw new SQLException("Failed to write JSON", e);
-            }
-            resultObject = writer.toString();
-
+            Object resultTransformedWithSchema = smartTransformResult(
+                    resultObject,
+                    this.Result.getSchema().getFields().get(columnIndex - 1));
+            resultObject = easyToJson(resultTransformedWithSchema);
         }
-        return (String) resultObject;
+        return resultObject.toString();
+    }
+
+    private Object smartTransformResult(Object resultObject, TableFieldSchema fieldDef) {
+        boolean isList = resultObject instanceof List;
+        boolean isMap = resultObject instanceof Map;
+        if (isMap && ((Map) resultObject).containsKey("v")) {
+            // All values in these nested structs from the API are wrapped up as {"v": <the_val>}, so we unwrap here
+            return smartTransformResult(((Map) resultObject).get("v"), fieldDef);
+        } else if (fieldDef.getMode().equals("REPEATED") && isList) {
+            List asList = ((List) resultObject);
+            ArrayList<Object> newList = new ArrayList<>();
+            for (Object obj : asList) {
+                newList.add(smartTransformResult(obj, fieldDef));
+            }
+            return newList;
+        } else if (fieldDef.getType().equals("RECORD") && isMap) {
+            Map asMap = ((Map) resultObject);
+            Object nested = asMap.get("f");
+            List<TableFieldSchema> nestedFields = fieldDef.getFields();
+            if (!(nested instanceof List) || nestedFields == null) {
+                // The API sent back something we don't understand
+                return resultObject;
+            }
+            List nestedValues = (List) nested;
+            if (nestedValues.size() != nestedFields.size()) {
+                return resultObject;
+            }
+            HashMap<String, Object> newMap = new HashMap<>();
+            for (int i = 0, n = nestedFields.size(); i < n; i++) {
+                TableFieldSchema nestedFieldDef = nestedFields.get(i);
+                newMap.put(nestedFieldDef.getName(), smartTransformResult(nestedValues.get(i), nestedFieldDef));
+            }
+            return newMap;
+        } else {
+            // This is just a plain value or the API sent back something we don't understand
+            return resultObject;
+        }
+    }
+
+
+    private String easyToJson(Object resultObject) throws SQLException {
+        Writer writer = new StringWriter();
+        try {
+            JsonGenerator gen = new JacksonFactory().createJsonGenerator(writer);
+            gen.serialize(resultObject);
+            gen.close();
+        } catch (IOException e) {
+            // Um, a string writer is not going to throw an IO exception, but fine.
+            throw new BQSQLException("Failed to write JSON", e);
+        }
+        return writer.toString();
     }
 
     /**

--- a/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
@@ -29,7 +29,6 @@
 
 package net.starschema.clouddb.jdbc;
 
-import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.services.bigquery.Bigquery;
 import com.google.api.services.bigquery.Bigquery.Jobs.Insert;
 import com.google.api.services.bigquery.model.DatasetList.Datasets;
@@ -44,7 +43,10 @@ import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -107,6 +109,16 @@ public class BQSupportFuncts {
             }
         } else {
             return null;
+        }
+
+        String useLegacySql = properties.getProperty("useLegacySql");
+        if (useLegacySql != null) {
+            if (properties.getProperty("type").equals("service")) {
+                forreturn += "&useLegacySql=" + useLegacySql;
+            }
+            else {
+                forreturn += "?useLegacySql=" + useLegacySql;
+            }
         }
 
         if (transformQuery != null && !full) {

--- a/src/test/java/BQJDBC/QueryResultTest/BQForwardOnlyResultSetFunctionTest.java
+++ b/src/test/java/BQJDBC/QueryResultTest/BQForwardOnlyResultSetFunctionTest.java
@@ -393,10 +393,10 @@ public class BQForwardOnlyResultSetFunctionTest {
         }
         Assert.assertNotNull(result);
         Assert.assertTrue(result.next());
-        Assert.assertEquals("{\"f\":[{\"v\":\"1\"},{\"v\":\"hello\"}]}", result.getString(1));
-        Assert.assertEquals("[{\"v\":\"a\"},{\"v\":\"b\"},{\"v\":\"c\"}]", result.getString(2));
-        Assert.assertEquals("[{\"v\":{\"f\":[{\"v\":\"1\"},{\"v\":\"hello\"}]}},{\"v\":{\"f\":[{\"v\":\"2\"},{\"v\":\"goodbye\"}]}}]", result.getString(3));
-        Assert.assertEquals("{\"f\":[{\"v\":\"1\"},{\"v\":[{\"v\":\"an\"},{\"v\":\"array\"}]}]}", result.getString(4));
+        Assert.assertEquals("{\"b\":\"hello\",\"a\":\"1\"}", result.getString(1));
+        Assert.assertEquals("[\"a\",\"b\",\"c\"]", result.getString(2));
+        Assert.assertEquals("[{\"b\":\"hello\",\"a\":\"1\"},{\"b\":\"goodbye\",\"a\":\"2\"}]", result.getString(3));
+        Assert.assertEquals("{\"b\":[\"an\",\"array\"],\"a\":\"1\"}", result.getString(4));
     }
 
     @Test

--- a/src/test/java/BQJDBC/QueryResultTest/BQForwardOnlyResultSetFunctionTest.java
+++ b/src/test/java/BQJDBC/QueryResultTest/BQForwardOnlyResultSetFunctionTest.java
@@ -179,35 +179,28 @@ public class BQForwardOnlyResultSetFunctionTest {
      */
     @Before
     public void NewConnection() {
-        NewConnection(false);
+        NewConnection(true);
     }
 
-     void NewConnection(boolean useLegaySql) {
+     void NewConnection(boolean useLegacySql) {
 
-        try {
-            if (BQForwardOnlyResultSetFunctionTest.con == null
-                    || !BQForwardOnlyResultSetFunctionTest.con.isValid(0)) {
-                this.logger.info("Testing the JDBC driver");
-                try {
-                    Class.forName("net.starschema.clouddb.jdbc.BQDriver");
-                    Properties props = BQSupportFuncts
-                            .readFromPropFile(getClass().getResource("/installedaccount1.properties").getFile());
-                    props.setProperty("useLegacySql", String.valueOf(useLegaySql));
-                    BQForwardOnlyResultSetFunctionTest.con = DriverManager.getConnection(
-                            BQSupportFuncts.constructUrlFromPropertiesFile(props),
-                            BQSupportFuncts.readFromPropFile(getClass().getResource("/installedaccount1.properties").getFile()));
-                } catch (Exception e) {
-                    e.printStackTrace();
-                    this.logger.error("Error in connection" + e.toString());
-                    Assert.fail("General Exception:" + e.toString());
-                }
-                this.logger.info(((BQConnection) BQForwardOnlyResultSetFunctionTest.con)
-                        .getURLPART());
-            }
-        } catch (SQLException e) {
-            logger.debug("Oops something went wrong", e);
-        }
-        if (useLegaySql) {
+         this.logger.info("Testing the JDBC driver");
+         try {
+             Class.forName("net.starschema.clouddb.jdbc.BQDriver");
+             Properties props = BQSupportFuncts
+                     .readFromPropFile(getClass().getResource("/installedaccount1.properties").getFile());
+             props.setProperty("useLegacySql", String.valueOf(useLegacySql));
+             BQForwardOnlyResultSetFunctionTest.con = DriverManager.getConnection(
+                     BQSupportFuncts.constructUrlFromPropertiesFile(props),
+                     BQSupportFuncts.readFromPropFile(getClass().getResource("/installedaccount1.properties").getFile()));
+         } catch (Exception e) {
+             e.printStackTrace();
+             this.logger.error("Error in connection" + e.toString());
+             Assert.fail("General Exception:" + e.toString());
+         }
+         this.logger.info(((BQConnection) BQForwardOnlyResultSetFunctionTest.con)
+                 .getURLPART());
+         if (useLegacySql) {
             this.QueryLoad();
         }
     }


### PR DESCRIPTION
~Obviously the format here could be better. This is taking the underlying data from what I assume is the d-jsonified BigQuery API response and re-JSONifying it. Going to at least glance at how hard it would be try to pull metadata out of the response and give things the right structure, rather than this naive JSONification. But if that looks like it will take a bit, it's still much much better to not explode.~

Fixed the format to return basically what you'd expect