### PR TITLE
Colons in dataset name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,5 +149,5 @@
     </plugins>
     <finalName>${project.artifactId}-${project.version}-thin</finalName>
   </build>
-  <version>1.8.9</version>
+  <version>1.9.0</version>
 </project>

--- a/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
@@ -110,7 +110,15 @@ public class BQConnection implements Connection {
         this.isclosed = false;
 
         try {
-            String pathParams = URLDecoder.decode(url.substring(url.lastIndexOf(":") + 1, url.indexOf('?')), "UTF-8");
+            Pattern pathParamsMatcher = Pattern.compile("^jdbc:BQDriver::?([^?]*)", Pattern.CASE_INSENSITIVE);
+            Matcher pathParamsMatchData = pathParamsMatcher.matcher(URLDecoder.decode(url, "UTF-8"));
+            String pathParams;
+            if (pathParamsMatchData.find()){
+                pathParams = pathParamsMatchData.group(1);
+            } else {
+                pathParams = URLDecoder.decode(url.substring(url.lastIndexOf(":") + 1, url.indexOf('?')), "UTF-8");
+            }
+
             Pattern projectAndDatasetMatcher = Pattern.compile("^([^/$]+)(?:/([^$]*))?$");
 
             Matcher matchData = projectAndDatasetMatcher.matcher(pathParams);

--- a/src/test/java/BQJDBC/QueryResultTest/JdbcUrlTest.java
+++ b/src/test/java/BQJDBC/QueryResultTest/JdbcUrlTest.java
@@ -11,6 +11,8 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Properties;
 
+import static org.junit.Assert.fail;
+
 /**
  * Created by steven on 10/21/15.
  */
@@ -30,6 +32,18 @@ public class JdbcUrlTest {
     @Test
     public void urlWithDefaultDatasetShouldWork() throws SQLException {
         Assert.assertEquals(properties.getProperty("dataset"), bq.getDataSet());
+    }
+
+    @Test
+    public void projectWithColons() throws SQLException {
+        String urlWithColonContainingProject = URL.replace(bq.getProjectId(), "before:after");
+        try {
+            BQConnection bq_with_colons = new BQConnection(urlWithColonContainingProject, new Properties());
+            // Some day we'll get rid of the whacky subbing in and out of colons with double underscores, but today is not that day
+            Assert.assertEquals("before__after", bq_with_colons.getProjectId());
+        } catch (SQLException e){
+            fail("failed to get or parse url: " + e.getMessage());
+        }
     }
 
     @Test


### PR DESCRIPTION
Match the known JDBC connection string for better parsing of the projectId in order to allow for colons in the projectId. If the expected connection string format is not matched then fallback to the old way of simply using the last occurence of a colon as the start index of the projectId/dataset path params.

While we're in here, fixup a test which expected HashMap serialization ordering to always be consistent.