### PR TITLE
Add metadata support for dates and records

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,5 +149,5 @@
     </plugins>
     <finalName>${project.artifactId}-${project.version}-thin</finalName>
   </build>
-  <version>1.9.2</version>
+  <version>1.9.3</version>
 </project>

--- a/src/main/java/net/starschema/clouddb/jdbc/BQPreparedStatement.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQPreparedStatement.java
@@ -307,6 +307,11 @@ public class BQPreparedStatement extends BQStatementRoot implements
     }
 
     @Override
+    public ResultSet executeQuery(String querySql) throws SQLException {
+        throw new BQSQLFeatureNotSupportedException("executeQuery(String querySQL)");
+    }
+
+    @Override
     public ParameterMetaData getParameterMetaData() throws SQLException {
         logger.debug("function call: getParameterMetaData()");
         // TODO IMPLEMENT

--- a/src/main/java/net/starschema/clouddb/jdbc/BQResultSetMetadata.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQResultSetMetadata.java
@@ -123,7 +123,7 @@ class BQResultsetMetaData implements ResultSetMetaData {
         if (Columntype.equals("DATE")) {
             return Date.class.getName();
         }
-        if (Columntype.equals("RECORD")) {
+        if (Columntype.equals("RECORD") || Columntype.equals("STRUCT")) {
             return Struct.class.getName();
         }
 

--- a/src/main/java/net/starschema/clouddb/jdbc/BQResultSetMetadata.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQResultSetMetadata.java
@@ -27,9 +27,11 @@
 
 package net.starschema.clouddb.jdbc;
 
+import java.sql.Date;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.Struct;
 import java.sql.Timestamp;
 import java.util.List;
 

--- a/src/main/java/net/starschema/clouddb/jdbc/BQResultSetMetadata.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQResultSetMetadata.java
@@ -200,6 +200,7 @@ class BQResultsetMetaData implements ResultSetMetaData {
      * java.sql.Types.TIMESTAMP<br>
      * java.sql.Types.DATE<br>
      * java.sql.Types.RECORD<br>
+     * java.sql.Types.STRUCT<br>
      * */
     @Override
     public int getColumnType(int column) throws SQLException {

--- a/src/main/java/net/starschema/clouddb/jdbc/BQResultSetMetadata.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQResultSetMetadata.java
@@ -118,6 +118,13 @@ class BQResultsetMetaData implements ResultSetMetaData {
         if (Columntype.equals("TIMESTAMP")) {
             return Timestamp.class.getName();
         }
+        if (Columntype.equals("DATE")) {
+            return Date.class.getName();
+        }
+        if (Columntype.equals("RECORD")) {
+            return Struct.class.getName();
+        }
+
         throw new BQSQLException("Unsupported Type: " + Columntype);
     }
 
@@ -189,6 +196,8 @@ class BQResultsetMetaData implements ResultSetMetaData {
      * java.sql.Types.BIGINT<br>
      * java.sql.Types.VARCHAR<br>
      * java.sql.Types.TIMESTAMP<br>
+     * java.sql.Types.DATE<br>
+     * java.sql.Types.RECORD<br>
      * */
     @Override
     public int getColumnType(int column) throws SQLException {
@@ -221,6 +230,14 @@ class BQResultsetMetaData implements ResultSetMetaData {
 
         if (Columntype.equals("TIMESTAMP")) {
             return java.sql.Types.TIMESTAMP;
+        }
+
+        if (Columntype.equals("DATE")) {
+            return java.sql.Types.DATE;
+        }
+
+        if (Columntype.equals("RECORD") || Columntype.equals("STRUCT")) {
+            return java.sql.Types.STRUCT;
         }
 
         throw new BQSQLException("Unsupported Type: " + Columntype); // May arise if a new data type is added to BigQuery. A new release of the driver would then be needed in order to map it correctly
@@ -272,6 +289,12 @@ class BQResultsetMetaData implements ResultSetMetaData {
         }
         if (Columntype.equals("TIMESTAMP")) {
             return 50; // TODO: better computation of the maximum length of a string representation of the date
+        }
+        if (Columntype.equals("DATE")) {
+            return 10;
+        }
+        if (Columntype.equals("RECORD") || Columntype.equals("STRUCT")) {
+            return 1024; // TODO: more accurate precision for RECORDs and STRUCTs
         }
         return 0;
     }

--- a/src/test/java/BQJDBC/QueryResultTest/PreparedStatementTests.java
+++ b/src/test/java/BQJDBC/QueryResultTest/PreparedStatementTests.java
@@ -149,24 +149,44 @@ public class PreparedStatementTests {
     }
 
     /**
-     * This test ensures that getColumnType supports the Date type
+     * This test ensures that getColumnType supports the following types: DOUBLE, BOOLEAN, BIGINT, VARCHAR, TIMESTAMP, DATE
+     * Note: RECORD/STRUCT are not tested here because PreparedStatementsTests run queries on Legacy SQL
      */
     @Test
-    public void ResultSetMetadataFunctionTestDateType() {
-        final String sql = "SELECT CAST(CURRENT_DATE() AS DATE)";
+    public void ResultSetMetadataFunctionTestTypes() {
+        final String[] queries = new String[]{
+                "SELECT 3.14",
+                "SELECT TRUE",
+                "SELECT 1",
+                "SELECT 'test'",
+                "SELECT CAST(CURRENT_TIMESTAMP() AS TIMESTAMP)",
+                "SELECT CAST(CURRENT_DATE() AS DATE)",
+        };
+        final int[] expectedType = new int[]{
+                java.sql.Types.DOUBLE,
+                java.sql.Types.BOOLEAN,
+                java.sql.Types.BIGINT,
+                java.sql.Types.VARCHAR,
+                java.sql.Types.TIMESTAMP,
+                java.sql.Types.DATE,
+        };
 
-        System.out.println("Running query:" + sql);
-        try {
-            PreparedStatement stm = PreparedStatementTests.con
-                    .prepareStatement(sql);
-            java.sql.ResultSet theResult = stm.executeQuery();
-            Assert.assertNotNull(theResult);
-            Assert.assertEquals("DATE type was not returned in metadata",
-                    java.sql.Types.DATE,
-                    theResult.getMetaData().getColumnType(1));
-        } catch (SQLException e) {
-            Assert.fail(e.toString());
+        for (int i = 0; i < queries.length; i ++) {
+            System.out.println("Running query: " + queries[i]);
+
+            try {
+                PreparedStatement stm = PreparedStatementTests.con
+                        .prepareStatement(queries[i]);
+                java.sql.ResultSet theResult = stm.executeQuery();
+                Assert.assertNotNull(theResult);
+                Assert.assertEquals("Expected type was not returned in metadata",
+                        expectedType[i],
+                        theResult.getMetaData().getColumnType(1));
+            } catch (SQLException e) {
+                Assert.fail(e.toString());
+            }
         }
+
         try {
             con.close();
         } catch (SQLException e) {

--- a/src/test/java/BQJDBC/QueryResultTest/PreparedStatementTests.java
+++ b/src/test/java/BQJDBC/QueryResultTest/PreparedStatementTests.java
@@ -140,6 +140,39 @@ public class PreparedStatementTests {
         } catch (SQLException e) {
             Assert.fail(e.toString());
         }
+        try {
+            con.close();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        con = null;
+    }
+
+    /**
+     * This test ensures that getColumnType supports the Date type
+     */
+    @Test
+    public void ResultSetMetadataFunctionTestDateType() {
+        final String sql = "SELECT CAST(CURRENT_DATE() AS DATE)";
+
+        System.out.println("Running query:" + sql);
+        try {
+            PreparedStatement stm = PreparedStatementTests.con
+                    .prepareStatement(sql);
+            java.sql.ResultSet theResult = stm.executeQuery();
+            Assert.assertNotNull(theResult);
+            Assert.assertEquals("DATE type was not returned in metadata",
+                    java.sql.Types.DATE,
+                    theResult.getMetaData().getColumnType(1));
+        } catch (SQLException e) {
+            Assert.fail(e.toString());
+        }
+        try {
+            con.close();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        con = null;
     }
 
     /**

--- a/src/test/java/BQJDBC/QueryResultTest/PreparedStatementTests.java
+++ b/src/test/java/BQJDBC/QueryResultTest/PreparedStatementTests.java
@@ -101,8 +101,6 @@ public class PreparedStatementTests {
     @Test
     public void outOfRangeTest() {
         final String sql = "SELECT corpus, COUNT(word) as wc FROM publicdata:samples.shakespeare WHERE corpus = ? GROUP BY corpus ORDER BY wc DESC LIMIT ?";
-        System.out.println("Test number: 01");
-        System.out.println("Running query:" + sql);
 
         final String first = "othello";
         final String second = "macbeth";
@@ -130,8 +128,6 @@ public class PreparedStatementTests {
     @Test
     public void ParameterlessTest() {
         final String sql = "SELECT TOP(word, 3), COUNT(*) FROM publicdata:samples.shakespeare";
-        System.out.println("Test number: 00");
-        System.out.println("Running query:" + sql);
         try {
             PreparedStatement stm = PreparedStatementTests.con
                     .prepareStatement(sql);
@@ -172,8 +168,6 @@ public class PreparedStatementTests {
         };
 
         for (int i = 0; i < queries.length; i ++) {
-            System.out.println("Running query: " + queries[i]);
-
             try {
                 PreparedStatement stm = PreparedStatementTests.con
                         .prepareStatement(queries[i]);
@@ -201,8 +195,6 @@ public class PreparedStatementTests {
     @Test
     public void setBigDecimalTest() {
         final String sql = "SELECT corpus, COUNT(word) as wc FROM publicdata:samples.shakespeare WHERE corpus = ? GROUP BY corpus ORDER BY wc DESC LIMIT ?";
-        System.out.println("Test number: 01");
-        System.out.println("Running query:" + sql);
 
         // final String first = "othello";
         final String second = "macbeth";
@@ -227,7 +219,6 @@ public class PreparedStatementTests {
             for (int i = 0; i < ColumnCount; i++) {
                 Line += String.format("%-32s", metadata.getColumnName(i + 1));
             }
-            System.out.println(Line + "\n");
 
             // Print out Column Values
             while (theResult.next()) {
@@ -238,7 +229,6 @@ public class PreparedStatementTests {
                     }
                     Line += String.format("%-32s", theResult.getString(i + 1));
                 }
-                System.out.println(Line);
                 actual++;
             }
 
@@ -258,8 +248,6 @@ public class PreparedStatementTests {
     @Test
     public void SetByteTest() {
         final String sql = "SELECT TOP(word, ?), COUNT(*) FROM publicdata:samples.shakespeare";
-        System.out.println("Test SetByteTest");
-        System.out.println("Running query:" + sql);
 
         // SET HOW MANY RESULT YOU WISH
         Byte COUNT = new Byte("3");
@@ -299,8 +287,6 @@ public class PreparedStatementTests {
         final String sql = "SELECT corpus FROM publicdata:samples.shakespeare WHERE LOWER(word)=? GROUP BY corpus ORDER BY corpus DESC LIMIT 5;";
         String[][] expectation = new String[][]{{"winterstale", "various",
                 "twogentlemenofverona", "twelfthnight", "troilusandcressida"}};
-        System.out.println("Test SetCharacterStreamTest");
-        System.out.println("Running query:" + sql);
         java.sql.ResultSet Result = null;
         try {
             PreparedStatement stm = PreparedStatementTests.con
@@ -334,21 +320,17 @@ public class PreparedStatementTests {
     public void setDateTest() {
         final String sql = "SELECT year, month, day, is_male, weight_pounds FROM publicdata:samples.natality"
                 + " WHERE year = INTEGER(LEFT( ? ,4)) AND month = ? AND is_male = ? ORDER BY weight_pounds DESC LIMIT 1000";
-        System.out.println("Test setDateTest");
-        System.out.println("Running query:" + sql);
 
         final String first = "1989-05-01";
         final boolean istrue = true;
         DateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
         java.util.Date date = null;
-        // System.out.println(String.valueOf(date.getTime()));
         try {
             date = formatter.parse(first);
         } catch (ParseException e2) {
             Assert.fail();
             e2.printStackTrace();
         }
-        System.out.println(String.valueOf(date.getTime()));
         java.sql.ResultSet theResult = null;
         java.sql.Date firstdate = new java.sql.Date(date.getTime());
         try {
@@ -370,7 +352,6 @@ public class PreparedStatementTests {
             for (int i = 0; i < ColumnCount; i++) {
                 Line += String.format("%-32s", metadata.getColumnName(i + 1));
             }
-            System.out.println(Line + "\n");
 
             // Print out Column Values
             while (theResult.next()) {
@@ -384,7 +365,6 @@ public class PreparedStatementTests {
                     // Assert.assertEquals(String.valueOf(istrue),theResult.getString(i+1));
                     Line += String.format("%-15s", theResult.getString(i + 1));
                 }
-                System.out.println(Line);
             }
         } catch (SQLException e) {
             Assert.fail(e.toString());
@@ -404,8 +384,6 @@ public class PreparedStatementTests {
         final String sql = "SELECT corpus,COUNT(word)/? as countn FROM publicdata:samples.shakespeare Group by corpus having countn=?";
         double number = 1849.5;
 
-        System.out.println("Test SetDoubleTest");
-        System.out.println("Running query:" + sql);
         java.sql.ResultSet Result = null;
         try {
             PreparedStatement stm = PreparedStatementTests.con
@@ -446,8 +424,6 @@ public class PreparedStatementTests {
         final String sql = "SELECT corpus,COUNT(word)/? as countn FROM publicdata:samples.shakespeare Group by corpus having countn=?";
         float number = 1849.5f;
 
-        System.out.println("Test SetFloatTest");
-        System.out.println("Running query:" + sql);
         java.sql.ResultSet Result = null;
         try {
             PreparedStatement stm = PreparedStatementTests.con
@@ -489,8 +465,6 @@ public class PreparedStatementTests {
     @Test
     public void setIntTest() {
         final String sql = "SELECT TOP(word, ?), COUNT(*) FROM publicdata:samples.shakespeare";
-        System.out.println("Test number: 01");
-        System.out.println("Running query:" + sql);
 
         // SET HOW MANY RESULT YOU WISH
         int COUNT = 3;
@@ -512,7 +486,6 @@ public class PreparedStatementTests {
             for (int i = 0; i < ColumnCount; i++) {
                 Line += String.format("%-32s", metadata.getColumnName(i + 1));
             }
-            System.out.println(Line + "\n");
 
             // Print out Column Values
             while (theResult.next()) {
@@ -520,7 +493,6 @@ public class PreparedStatementTests {
                 for (int i = 0; i < ColumnCount; i++) {
                     Line += String.format("%-32s", theResult.getString(i + 1));
                 }
-                System.out.println(Line);
                 Actual++;
             }
         } catch (SQLException e) {
@@ -540,8 +512,6 @@ public class PreparedStatementTests {
         final String sql = "SELECT corpus,COUNT(word) as countn FROM publicdata:samples.shakespeare Group by corpus having countn>? limit 10";
         long number = 5200;
 
-        System.out.println("Test SetLongTest");
-        System.out.println("Running query:" + sql);
         java.sql.ResultSet Result = null;
         try {
             PreparedStatement stm = PreparedStatementTests.con
@@ -578,8 +548,6 @@ public class PreparedStatementTests {
     @Test
     public void setStringTest() {
         final String sql = "SELECT corpus, COUNT(word) as wc FROM publicdata:samples.shakespeare WHERE corpus = ? GROUP BY corpus ORDER BY wc DESC LIMIT ?";
-        System.out.println("Test number: 01");
-        System.out.println("Running query:" + sql);
 
         final String first = "othello";
         final String second = "macbeth";
@@ -605,7 +573,6 @@ public class PreparedStatementTests {
             for (int i = 0; i < ColumnCount; i++) {
                 Line += String.format("%-32s", metadata.getColumnName(i + 1));
             }
-            System.out.println(Line + "\n");
 
             // Print out Column Values
             while (theResult.next()) {
@@ -616,7 +583,6 @@ public class PreparedStatementTests {
                     }
                     Line += String.format("%-32s", theResult.getString(i + 1));
                 }
-                System.out.println(Line);
                 actual++;
             }
         } catch (SQLException e) {


### PR DESCRIPTION
As title suggests: add support for getting info about `DATE` and `RECORD`/`STRUCT`-type columns. 

Before this: `ResultSet.getMetaData().getcolumnType([index of a DATE-type column])` -> `Unsupported Type: DATE`
