### PR TITLE
Add metadata support for DATETIME data type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,5 +149,5 @@
     </plugins>
     <finalName>${project.artifactId}-${project.version}-thin</finalName>
   </build>
-  <version>1.9.5</version>
+  <version>1.9.6</version>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -149,5 +149,5 @@
     </plugins>
     <finalName>${project.artifactId}-${project.version}-thin</finalName>
   </build>
-  <version>1.9.4</version>
+  <version>1.9.5</version>
 </project>

--- a/src/main/java/net/starschema/clouddb/jdbc/BQResultSetMetadata.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQResultSetMetadata.java
@@ -305,6 +305,9 @@ class BQResultsetMetaData implements ResultSetMetaData {
         if (Columntype.equals("DATE")) {
             return 10;
         }
+        if (Columntype.equals("DATETIME")) {
+            return 50;
+        }
         if (Columntype.equals("RECORD") || Columntype.equals("STRUCT")) {
             return 1024; // TODO: more accurate precision for RECORDs and STRUCTs
         }

--- a/src/main/java/net/starschema/clouddb/jdbc/BQResultSetMetadata.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQResultSetMetadata.java
@@ -240,6 +240,10 @@ class BQResultsetMetaData implements ResultSetMetaData {
             return java.sql.Types.DATE;
         }
 
+        if (Columntype.equals("DATETIME")) {
+            return java.sql.Types.TIMESTAMP;
+        }
+
         if (Columntype.equals("NUMERIC")) {
             return java.sql.Types.NUMERIC;
         }

--- a/src/test/java/BQJDBC/QueryResultTest/PreparedStatementTests.java
+++ b/src/test/java/BQJDBC/QueryResultTest/PreparedStatementTests.java
@@ -145,7 +145,7 @@ public class PreparedStatementTests {
     }
 
     /**
-     * This test ensures that getColumnType supports the following types: DOUBLE, BOOLEAN, BIGINT, VARCHAR, TIMESTAMP, DATE
+     * This test ensures that getColumnType supports the following types: DOUBLE, BOOLEAN, BIGINT, VARCHAR, TIMESTAMP, DATE, DATETIME
      * Note: RECORD/STRUCT are not tested here because PreparedStatementsTests run queries on Legacy SQL
      */
     @Test
@@ -158,6 +158,7 @@ public class PreparedStatementTests {
                 "SELECT CAST(CURRENT_TIMESTAMP() AS TIMESTAMP)",
                 "SELECT CAST(CURRENT_DATE() AS DATE)",
                 "SELECT CAST('1' AS NUMERIC)",
+                "SELECT CAST('1' AS DATETIME)"
         };
         final int[] expectedType = new int[]{
                 java.sql.Types.DOUBLE,
@@ -167,6 +168,7 @@ public class PreparedStatementTests {
                 java.sql.Types.TIMESTAMP,
                 java.sql.Types.DATE,
                 java.sql.Types.NUMERIC,
+                java.sql.Types.TIMESTAMP,
         };
 
         for (int i = 0; i < queries.length; i ++) {


### PR DESCRIPTION
Note that `DATETIME` is not a native `java.sql.Types` type, so just categorize it as a `TIMESTAMP` when retrieving column types for `DATETIME`s. 