### PR TITLE
Switch driver to run with synchronous jobs.query endpoint

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -27,6 +27,14 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
       </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <source>7</source>
+                <target>7</target>
+            </configuration>
+        </plugin>
     </plugins>
   </build>
   <repositories>

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -27,14 +27,6 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
       </plugin>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-                <source>7</source>
-                <target>7</target>
-            </configuration>
-        </plugin>
     </plugins>
   </build>
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -159,5 +159,5 @@
     </plugins>
     <finalName>${project.artifactId}-${project.version}-thin</finalName>
   </build>
-  <version>2.0.3</version>
+  <version>2.1.0</version>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -62,11 +62,6 @@
       <version>v1-rev66-1.25.0</version>
     </dependency>
     <dependency>
-      <groupId>com.google.apis</groupId>
-      <artifactId>google-api-services-iamcredentials</artifactId>
-      <version>v1-rev66-1.25.0</version>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.8.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,12 @@
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-bigquery</artifactId>
-      <version>v2-rev431-1.25.0</version>
+      <version>v2-rev20200523-1.30.9</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-iamcredentials</artifactId>
+      <version>v1-rev66-1.25.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -128,8 +133,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>8</source>
+          <target>8</target>
         </configuration>
       </plugin>
       <plugin>
@@ -149,5 +154,5 @@
     </plugins>
     <finalName>${project.artifactId}-${project.version}-thin</finalName>
   </build>
-  <version>1.9.6</version>
+  <version>2.0.3</version>
 </project>

--- a/src/main/java/net/starschema/clouddb/cmdlineverification/Oauth2Bigquery.java
+++ b/src/main/java/net/starschema/clouddb/cmdlineverification/Oauth2Bigquery.java
@@ -593,10 +593,6 @@ public class Oauth2Bigquery {
 
         public void setOauthToken(String oauthToken) { this.oauthToken = oauthToken; }
 
-        public String getUserAgent() {
-            return this.userAgent;
-        }
-
         public String getOauthToken() {return this.oauthToken; }
 
         @Override

--- a/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
@@ -69,7 +69,7 @@ public class BQConnection implements Connection {
 
     private Long maxBillingBytes;
 
-    private boolean useQueryApi = false;
+    private boolean useQueryApi;
 
     private final Set<BQStatementRoot> runningStatements = Collections.synchronizedSet(new HashSet<BQStatementRoot>());
 
@@ -164,8 +164,8 @@ public class BQConnection implements Connection {
         String withServiceAccountParam = caseInsensitiveProps.getProperty("withserviceaccount");
         Boolean serviceAccount = (withServiceAccountParam != null) && Boolean.parseBoolean(withServiceAccountParam);
 
-        String useQueryApiParam = caseInsensitiveProps.getProperty("useQueryApi");
-        useQueryApi = (useQueryApiParam != null) && Boolean.parseBoolean(useQueryApiParam);
+        String useQueryApiParam = caseInsensitiveProps.getProperty("usequeryapi");
+        useQueryApi = Boolean.parseBoolean(useQueryApiParam);
 
         // extract transformQuery property
         String transformQueryParam = caseInsensitiveProps.getProperty("transformquery");

--- a/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
@@ -1053,7 +1053,7 @@ public class BQConnection implements Connection {
      *
      * This API is faster by avoiding the async overhead of job polling, but does not currently support maxBillingGBs.
      * */
-    boolean getUseQueryApi() {
+    boolean shouldUseQueryApi() {
         return useQueryApi;
     }
 }

--- a/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
@@ -166,6 +166,7 @@ public class BQConnection implements Connection {
         String withServiceAccountParam = caseInsensitiveProps.getProperty("withserviceaccount");
         Boolean serviceAccount = (withServiceAccountParam != null) && Boolean.parseBoolean(withServiceAccountParam);
 
+        // There's really no reason anyone would ever not want to use this... but leave it in for a bit as a bailout switch
         String useQueryApiParam = caseInsensitiveProps.getProperty("usequeryapi");
         useQueryApi = useQueryApiParam == null || !useQueryApiParam.equalsIgnoreCase("false");
 

--- a/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
@@ -165,7 +165,7 @@ public class BQConnection implements Connection {
         Boolean serviceAccount = (withServiceAccountParam != null) && Boolean.parseBoolean(withServiceAccountParam);
 
         String useQueryApiParam = caseInsensitiveProps.getProperty("usequeryapi");
-        useQueryApi = Boolean.parseBoolean(useQueryApiParam);
+        useQueryApi = useQueryApiParam == null || !useQueryApiParam.equalsIgnoreCase("false");
 
         // extract transformQuery property
         String transformQueryParam = caseInsensitiveProps.getProperty("transformquery");

--- a/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
@@ -1063,7 +1063,8 @@ public class BQConnection implements Connection {
     /**
      * Returns true if queries on this connection should use the synchronous jobs.query api to run queries.
      *
-     * This API is faster by avoiding the async overhead of job polling, but does not currently support maxBillingGBs.
+     * This is the default, and the old, async API is being left in as a bailout switch in case there is some use case
+     * that only it supports that a client discovers.
      * */
     boolean shouldUseQueryApi() {
         return useQueryApi;

--- a/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
@@ -69,6 +69,8 @@ public class BQConnection implements Connection {
 
     private Long maxBillingBytes;
 
+    private boolean useQueryApi = false;
+
     private final Set<BQStatementRoot> runningStatements = Collections.synchronizedSet(new HashSet<BQStatementRoot>());
 
     /** Boolean to determine, to use or doesn't use the ANTLR parser */
@@ -161,6 +163,9 @@ public class BQConnection implements Connection {
         // extract withServiceAccount property
         String withServiceAccountParam = caseInsensitiveProps.getProperty("withserviceaccount");
         Boolean serviceAccount = (withServiceAccountParam != null) && Boolean.parseBoolean(withServiceAccountParam);
+
+        String useQueryApiParam = caseInsensitiveProps.getProperty("useQueryApi");
+        useQueryApi = (useQueryApiParam != null) && Boolean.parseBoolean(useQueryApiParam);
 
         // extract transformQuery property
         String transformQueryParam = caseInsensitiveProps.getProperty("transformquery");
@@ -1041,5 +1046,14 @@ public class BQConnection implements Connection {
 
     public Long getMaxBillingBytes() {
         return maxBillingBytes;
+    }
+
+    /**
+     * Returns true if queries on this connection should use the synchronous jobs.query api to run queries.
+     *
+     * This API is faster by avoiding the async overhead of job polling, but does not currently support maxBillingGBs.
+     * */
+    boolean getUseQueryApi() {
+        return useQueryApi;
     }
 }

--- a/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
@@ -106,7 +106,7 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
      * Constructor for the forward only resultset
      * @param bigquery - the bigquery client to be used to connect
      * @param projectId - the project which contains the Job
-     * @param completedJob - the Job ID, which will be used to get the results
+     * @param completedJob - the Job ID, which will be used to get the results, can be null if prefetchedAllRows is true
      * @param bqStatementRoot - reference for the Statement which created the result
      * @param prefetchedRows - array of rows already fetched from BigQuery.
      * @param prefetchedAllRows - true if all rows have already been fetched and we should not ask for any more.

--- a/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
@@ -31,10 +31,7 @@ import com.google.api.client.json.JsonGenerator;
 import com.google.api.client.json.jackson.JacksonFactory;
 import com.google.api.client.util.Data;
 import com.google.api.services.bigquery.Bigquery;
-import com.google.api.services.bigquery.model.GetQueryResultsResponse;
-import com.google.api.services.bigquery.model.Job;
-import com.google.api.services.bigquery.model.TableFieldSchema;
-import com.google.api.services.bigquery.model.TableRow;
+import com.google.api.services.bigquery.model.*;
 import org.apache.log4j.Logger;
 
 import java.io.*;
@@ -68,7 +65,10 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
     protected boolean wasnull = false;
 
     /** The Array which get iterated with cursor it's size can be set with FETCH_SIZE*/
-    protected Object[] RowsofResult;
+    protected List<TableRow> rowsofResult;
+
+    /** True if on init we have been passed all the rows in the result already. */
+    private boolean prefetchedAllRows = false;
 
     /** This holds if the resultset is closed or not */
     protected boolean closed = false;
@@ -81,8 +81,8 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
     protected boolean AT_FIRST = true;
     /** REference for the original statement which created this resultset     */
     private Statement Statementreference;
-    /** First page of the Results */
-    private GetQueryResultsResponse Result;
+    /** schema of results */
+    private TableSchema schema;
     /** BigQuery Client */
     private Bigquery bigquery;
     /** the ProjectId */
@@ -97,35 +97,53 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
             .ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
             .withZone(ZoneId.of("UTC"));
 
+    public BQForwardOnlyResultSet(Bigquery bigquery, String projectId,
+                                  Job completedJob, BQStatementRoot bqStatementRoot) throws SQLException {
+        this(bigquery, projectId, completedJob, bqStatementRoot, null, false, null);
+    }
+
     /**
      * Constructor for the forward only resultset
      * @param bigquery - the bigquery client to be used to connect
      * @param projectId - the project which contains the Job
      * @param completedJob - the Job ID, which will be used to get the results
      * @param bqStatementRoot - reference for the Statement which created the result
+     * @param prefetchedRows - array of rows already fetched from BigQuery.
+     * @param prefetchedAllRows - true if all rows have already been fetched and we should not ask for any more.
      * @throws SQLException - if we fail to get the results
      */
     public BQForwardOnlyResultSet(Bigquery bigquery, String projectId,
-                                  Job completedJob, BQStatementRoot bqStatementRoot) throws SQLException {
+                                  Job completedJob, BQStatementRoot bqStatementRoot,
+                                  List<TableRow> prefetchedRows, boolean prefetchedAllRows,
+                                  TableSchema schema
+                                  ) throws SQLException {
         logger.debug("Created forward only resultset TYPE_FORWARD_ONLY");
         this.Statementreference = (Statement) bqStatementRoot;
         this.bigquery = bigquery;
         this.completedJob = completedJob;
         this.projectId = projectId;
-        // initial load
-        try {
-            this.Result = BQSupportFuncts.getQueryResultsDivided(bigquery,
-                    projectId, completedJob, FETCH_POS, FETCH_SIZE);
-        } catch (IOException e) {
-            throw new BQSQLException("Failed to retrieve data", e);
-        } //should not happen
-        if (this.Result == null) {  //if we don't have results at all
-            this.RowsofResult = null;
-        } else if (this.Result.getRows() == null) {  //if we got results, but it was empty
-            this.RowsofResult = null;
-        } else {                        //we got results, it wasn't empty
-            this.RowsofResult = this.Result.getRows().toArray();
-            FETCH_POS = FETCH_POS.add(BigInteger.valueOf((long) this.RowsofResult.length));
+        if (prefetchedRows != null) {
+            this.rowsofResult = prefetchedRows;
+            this.prefetchedAllRows = prefetchedAllRows;
+            this.schema = schema;
+        } else {
+            // initial load
+            GetQueryResultsResponse result;
+            try {
+                result = BQSupportFuncts.getQueryResultsDivided(bigquery,
+                        projectId, completedJob, FETCH_POS, FETCH_SIZE);
+            } catch (IOException e) {
+                throw new BQSQLException("Failed to retrieve data", e);
+            } //should not happen
+            if (result == null) {  //if we don't have results at all
+                this.rowsofResult = null;
+            } else if (result.getRows() == null) {  //if we got results, but it was empty
+                this.rowsofResult = null;
+            } else {                        //we got results, it wasn't empty
+                this.rowsofResult = result.getRows();
+                this.schema = result.getSchema();
+                FETCH_POS = FETCH_POS.add(BigInteger.valueOf(this.rowsofResult.size()));
+            }
         }
     }
 
@@ -143,7 +161,7 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
             return null;
         }
 
-        String Columntype = this.Result.getSchema().getFields().get(columnIndex - 1).getType();
+        String Columntype = this.schema.getFields().get(columnIndex - 1).getType();
 
         try {
             if (Columntype.equals("STRING")) {
@@ -277,8 +295,8 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
             throw new BQSQLException("ColumnIndex is not valid");
         }
 
-        if (this.RowsofResult == null) throw new BQSQLException("Invalid position!");
-        Object resultObject = ((TableRow) this.RowsofResult[this.Cursor]).getF().get(columnIndex - 1).getV();
+        if (this.rowsofResult == null) throw new BQSQLException("Invalid position!");
+        Object resultObject = this.rowsofResult.get(this.Cursor).getF().get(columnIndex - 1).getV();
         if (Data.isNull(resultObject)) {
             this.wasnull = true;
             return null;
@@ -291,7 +309,7 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
         if (resultObject instanceof List || resultObject instanceof Map) {
             Object resultTransformedWithSchema = smartTransformResult(
                     resultObject,
-                    this.Result.getSchema().getFields().get(columnIndex - 1));
+                    schema.getFields().get(columnIndex - 1));
             resultObject = easyToJson(resultTransformedWithSchema);
         }
         return resultObject.toString();
@@ -417,7 +435,7 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
     public void close() throws SQLException {
         // TODO free occupied resources
         this.closed = true;
-        this.RowsofResult = null;
+        this.rowsofResult = null;
     }
 
     /**
@@ -909,7 +927,7 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
         if (this.isClosed()) {
             throw new BQSQLException("This Resultset is Closed");
         }
-        return new BQResultsetMetaData(this.Result);
+        return new BQResultsetMetaData(schema, projectId);
     }
 
     /**
@@ -1393,28 +1411,38 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
         if (this.isClosed()) {
             throw new BQSQLException("This Resultset is Closed");
         }
-        if (this.RowsofResult == null) {
+        if (this.rowsofResult == null) {
             return false;
         }
-        if (Cursor < FETCH_SIZE && Cursor < RowsofResult.length - 1) {
+        if (Cursor < FETCH_SIZE && Cursor < rowsofResult.size() - 1) {
             if (Cursor == -1) {
                 AT_FIRST = true;
             } else AT_FIRST = false;
            Cursor++;
            return true;
         }
+
+        if (this.prefetchedAllRows) {
+            // Nothing more to do, we've scrolled through all the rows we have.
+            this.rowsofResult = null; // this is how we remember we are out of rows
+            return false;
+        }
+
+        GetQueryResultsResponse result;
         try {
-            this.Result = BQSupportFuncts.getQueryResultsDivided(bigquery,
+             result = BQSupportFuncts.getQueryResultsDivided(bigquery,
                     projectId, completedJob, FETCH_POS, FETCH_SIZE);
         }
         catch (IOException e) {
-        } //should not happen
-        if (this.Result.getRows() == null) {
-            this.RowsofResult = null;
+            //should not happen ... according to whoever cooked this up back in the day
+            throw new BQSQLException("failed to fetch more results", e);
+        }
+        if (result.getRows() == null) {
+            this.rowsofResult = null;
             return false;
         }
-        this.RowsofResult = this.Result.getRows().toArray();
-        FETCH_POS = FETCH_POS.add(BigInteger.valueOf((long)this.RowsofResult.length));
+        this.rowsofResult = result.getRows();
+        FETCH_POS = FETCH_POS.add(BigInteger.valueOf((long)this.rowsofResult.size()));
         Cursor = 0;
         return true;
     }

--- a/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
@@ -76,7 +76,7 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
     /**Paging size, the original result will be paged by FETCH_SIZE rows     */
     protected int FETCH_SIZE = 5000;
     /**The Fetched rows count at the original results     */
-    protected BigInteger FETCH_POS = BigInteger.ZERO;
+    protected BigInteger fetchPos = BigInteger.ZERO;
     /** Are we at the first row? */
     protected boolean AT_FIRST = true;
     /** REference for the original statement which created this resultset     */
@@ -124,6 +124,7 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
         this.projectId = projectId;
         if (prefetchedRows != null) {
             this.rowsofResult = prefetchedRows;
+            fetchPos = fetchPos.add(BigInteger.valueOf(this.rowsofResult.size()));
             this.prefetchedAllRows = prefetchedAllRows;
             this.schema = schema;
         } else {
@@ -131,7 +132,7 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
             GetQueryResultsResponse result;
             try {
                 result = BQSupportFuncts.getQueryResultsDivided(bigquery,
-                        projectId, completedJob, FETCH_POS, FETCH_SIZE);
+                        projectId, completedJob, fetchPos, FETCH_SIZE);
             } catch (IOException e) {
                 throw new BQSQLException("Failed to retrieve data", e);
             } //should not happen
@@ -142,7 +143,7 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
             } else {                        //we got results, it wasn't empty
                 this.rowsofResult = result.getRows();
                 this.schema = result.getSchema();
-                FETCH_POS = FETCH_POS.add(BigInteger.valueOf(this.rowsofResult.size()));
+                fetchPos = fetchPos.add(BigInteger.valueOf(this.rowsofResult.size()));
             }
         }
     }
@@ -1431,7 +1432,7 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
         GetQueryResultsResponse result;
         try {
              result = BQSupportFuncts.getQueryResultsDivided(bigquery,
-                    projectId, completedJob, FETCH_POS, FETCH_SIZE);
+                    projectId, completedJob, fetchPos, FETCH_SIZE);
         }
         catch (IOException e) {
             //should not happen ... according to whoever cooked this up back in the day
@@ -1442,7 +1443,7 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
             return false;
         }
         this.rowsofResult = result.getRows();
-        FETCH_POS = FETCH_POS.add(BigInteger.valueOf((long)this.rowsofResult.size()));
+        fetchPos = fetchPos.add(BigInteger.valueOf((long)this.rowsofResult.size()));
         Cursor = 0;
         return true;
     }

--- a/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
@@ -239,7 +239,7 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
         return new BigDecimal(value);
     }
 
-    private Date toDate(String value, Calendar cal) throws SQLException {
+    static Date toDate(String value, Calendar cal) throws SQLException {
         // Dates in BigQuery come back in the YYYY-MM-DD format
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
         try {

--- a/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
@@ -122,9 +122,11 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
         this.bigquery = bigquery;
         this.completedJob = completedJob;
         this.projectId = projectId;
-        if (prefetchedRows != null) {
+        if (prefetchedRows != null || prefetchedAllRows) {
+            // prefetchedAllRows can be true with rows null for an empty result set
             this.rowsofResult = prefetchedRows;
-            fetchPos = fetchPos.add(BigInteger.valueOf(this.rowsofResult.size()));
+            if (prefetchedRows != null)
+                fetchPos = fetchPos.add(BigInteger.valueOf(this.rowsofResult.size()));
             this.prefetchedAllRows = prefetchedAllRows;
             this.schema = schema;
         } else {

--- a/src/main/java/net/starschema/clouddb/jdbc/BQResultSetMetadata.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQResultSetMetadata.java
@@ -28,10 +28,10 @@
 package net.starschema.clouddb.jdbc;
 
 import com.google.api.services.bigquery.model.GetQueryResultsResponse;
+import com.google.api.services.bigquery.model.QueryResponse;
 import com.google.api.services.bigquery.model.TableFieldSchema;
 import com.google.api.services.bigquery.model.TableSchema;
 import org.apache.log4j.Logger;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.sql.*;
 import java.util.List;
@@ -45,6 +45,8 @@ class BQResultsetMetaData implements ResultSetMetaData {
 
     TableSchema schema;
     String projectId;
+
+    QueryResponse result = null;
 
     /** Logger instance */
     Logger logger = Logger.getLogger(BQResultsetMetaData.class.getName());
@@ -317,28 +319,10 @@ class BQResultsetMetaData implements ResultSetMetaData {
      */
     @Override
     public int getScale(int column) throws SQLException {
-        // TODO: come back to this
-        throw new NotImplementedException();
-//        if (this.getColumnType(column) == java.sql.Types.DOUBLE) {
-//            int max = 0;
-//            schema.getFields().get(0)
-//            for (int i = 0; i < this.result.getRows().size(); i++) {
-//                Object rowdataObject = this.result.getRows().get(i).getF().get(column - 1).getV();
-//                if (Data.isNull(rowdataObject)) {
-//                    return 0;
-//                }
-//                String rowdata = (String) rowdataObject;
-//                if (rowdata.contains(".")) {
-//                    int pointback = rowdata.length() - rowdata.indexOf(".");
-//                    if (pointback > max) {
-//                        pointback = max;
-//                    }
-//                }
-//            }
-//            return max;
-//        } else {
-//            return 0;
-//        }
+        // This returns zero always. It would be better for it to throw a NotImplemented exception,
+        // but at one point it was written with some code that tried to do something silly with decimals but always
+        // ended up returning zero, so for now just go with constant return 0.
+        return 0;
     }
 
     /**

--- a/src/main/java/net/starschema/clouddb/jdbc/BQScrollableResultSet.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQScrollableResultSet.java
@@ -40,6 +40,8 @@ import java.sql.Statement;
 import java.sql.Timestamp;
 import java.util.List;
 
+import static net.starschema.clouddb.jdbc.BQForwardOnlyResultSet.toDate;
+
 /**
  * This class implements the java.sql.ResultSet interface its superclass is
  * ScrollableResultset
@@ -178,6 +180,16 @@ public class BQScrollableResultSet extends ScrollableResultset<Object> implement
                     long val = new BigDecimal(result).longValue() * 1000;
                     return new Timestamp(val);
                 }
+                if (Columntype.equals("DATETIME")) {
+                    // Date time represents a "clock face" time and so should NOT be processed into an actual time
+                    return result;
+                }
+                if (Columntype.equals("NUMERIC")) {
+                    return new BigDecimal(result);
+                }
+                if (Columntype.equals("DATE")) {
+                    return toDate(result, null);
+                }
                 throw new BQSQLException("Unsupported Type");
             } catch (NumberFormatException e) {
                 throw new BQSQLException(e);
@@ -211,8 +223,8 @@ public class BQScrollableResultSet extends ScrollableResultset<Object> implement
         if (this.isClosed()) {
             throw new BQSQLException("This Resultset is Closed");
         }
-        String result = (String) ((TableRow) this.RowsofResult[this.Cursor]).getF()
-                .get(columnIndex - 1).getV();
+        String result = ((TableRow) this.RowsofResult[this.Cursor]).getF()
+                .get(columnIndex - 1).getV().toString();
         if (result == null) {
             this.wasnull = true;
         } else {

--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
@@ -140,8 +140,9 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
                         (long) 10 * 1000, // we need this to respond fast enough to avoid any socket timeouts
                         (long) getMaxRows()
                 );
-                boolean fetchedAll = qr.getJobComplete() && (qr.getTotalRows().equals(BigInteger.ZERO) ||
-                        qr.getTotalRows().equals(BigInteger.valueOf(qr.getRows().size())));
+                boolean fetchedAll = qr.getJobComplete() && qr.getTotalRows() != null &&
+                        (qr.getTotalRows().equals(BigInteger.ZERO) ||
+                                (qr.getRows() != null && qr.getTotalRows().equals(BigInteger.valueOf(qr.getRows().size()))));
                 // Don't look up the job if we have nothing else we need to do
                 referencedJob = fetchedAll ?
                         null :

--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
@@ -136,7 +136,7 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
                         querySql,
                         connection.getDataSet(),
                         this.connection.getUseLegacySql(),
-                        this.connection.getMaxBillingBytes(),
+                        !unlimitedBillingBytes ? this.connection.getMaxBillingBytes() : null,
                         (long) querytimeout * 1000,
                         (long) getMaxRows()
                 );

--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
@@ -143,7 +143,8 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
                         connection.getDataSet(),
                         this.connection.getUseLegacySql(),
                         this.connection.getMaxBillingBytes(),
-                        (long) querytimeout * 1000
+                        (long) querytimeout * 1000,
+                        (long) getMaxRows()
                 );
                 if (qr.getJobComplete()) {
                     boolean fetchedAll = qr.getTotalRows().equals(BigInteger.ZERO) ||

--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
@@ -137,11 +137,11 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
                         connection.getDataSet(),
                         this.connection.getUseLegacySql(),
                         !unlimitedBillingBytes ? this.connection.getMaxBillingBytes() : null,
-                        (long) querytimeout * 1000,
+                        (long) 10 * 1000, // we need this to respond fast enough to avoid any socket timeouts
                         (long) getMaxRows()
                 );
-                boolean fetchedAll = qr.getTotalRows().equals(BigInteger.ZERO) ||
-                        qr.getTotalRows().equals(BigInteger.valueOf(qr.getRows().size()));
+                boolean fetchedAll = qr.getJobComplete() && (qr.getTotalRows().equals(BigInteger.ZERO) ||
+                        qr.getTotalRows().equals(BigInteger.valueOf(qr.getRows().size())));
                 // Don't look up the job if we have nothing else we need to do
                 referencedJob = fetchedAll ?
                         null :

--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
@@ -48,6 +48,11 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
     private Job job;
 
     /**
+     * Enough time to give most fast queries time to complete, but not too long so that we worry about
+     * having our socket closed by any reasonable intermediate component. */
+    private static final long SYNC_TIMEOUT_MILLIS = 10 * 1000;
+
+    /**
      * Constructor for BQStatement object just initializes local variables
      *
      * @param projectid
@@ -137,7 +142,7 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
                         connection.getDataSet(),
                         this.connection.getUseLegacySql(),
                         !unlimitedBillingBytes ? this.connection.getMaxBillingBytes() : null,
-                        (long) 10 * 1000, // we need this to respond fast enough to avoid any socket timeouts
+                        SYNC_TIMEOUT_MILLIS, // we need this to respond fast enough to avoid any socket timeouts
                         (long) getMaxRows()
                 );
                 boolean fetchedAll = qr.getJobComplete() && qr.getTotalRows() != null &&

--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatementRoot.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatementRoot.java
@@ -265,7 +265,8 @@ public abstract class BQStatementRoot {
                         connection.getDataSet(),
                         this.connection.getUseLegacySql(),
                         billingBytes,
-                        (long) querytimeout * 1000
+                        (long) querytimeout * 1000,
+                        (long) getMaxRows()
                 );
                 if (qr.getJobComplete()) {
                     if (qr.getTotalRows().equals(BigInteger.valueOf(qr.getRows().size()))) {
@@ -733,15 +734,10 @@ public abstract class BQStatementRoot {
     }
 
     /**
-     * <p>
-     * <h1>Implementation Details:</h1><br>
-     * arg0 == 0 ? arg0 : Integer.MAX_VALUE - 1
-     * </p>
-     *
-     * @throws BQSQLException
+     * NOTE: can pass 0 or negative to set to unlimited
      */
-    public void setMaxRows(int arg0) throws SQLException {
-        this.resultMaxRowCount = arg0 == 0 ? arg0 : Integer.MAX_VALUE - 1;
+    public void setMaxRows(int newMax) {
+        this.resultMaxRowCount = newMax <= 0 ? Integer.MAX_VALUE - 1 : newMax;
     }
 
     /**

--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatementRoot.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatementRoot.java
@@ -253,6 +253,22 @@ public abstract class BQStatementRoot {
         Long billingBytes = !unlimitedBillingBytes ? this.connection.getMaxBillingBytes() : null;
 
         try {
+            if (this.connection.getUseQueryApi()) {
+                Job synchronouslyExecutedJob = BQSupportFuncts.runQuery(
+                        this.connection.getBigquery(),
+                        this.ProjectId,
+                        querySql,
+                        connection.getDataSet(),
+                        this.connection.getUseLegacySql(),
+                        billingBytes,
+                        (long) querytimeout * 1000
+                );
+                return new BQForwardOnlyResultSet(
+                        this.connection.getBigquery(),
+                        this.ProjectId.replace("__", ":").replace("_", "."),
+                        synchronouslyExecutedJob, this);
+            }
+
             // Gets the Job reference of the completed job with give Query
             referencedJob = BQSupportFuncts.startQuery(
                     this.connection.getBigquery(),

--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatementRoot.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatementRoot.java
@@ -61,7 +61,7 @@ public abstract class BQStatementRoot {
     BQConnection connection;
 
     /** Variable that stores the set query timeout */
-    int querytimeout = Integer.MAX_VALUE;
+    int querytimeout = Integer.MAX_VALUE / 1000 - 1;
     /** Instance of log4j.Logger */
     /**
      * Variable stores the time an execute is made

--- a/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
@@ -667,7 +667,8 @@ public class BQSupportFuncts {
 
     static QueryResponse runSyncQuery(Bigquery bigquery, String projectId,
                                               String querySql, String dataSet, Boolean useLegacySql,
-                                              Long maxBillingBytes, Long queryTimeoutMs) throws IOException {
+                                              Long maxBillingBytes, Long queryTimeoutMs, Long maxResults
+    ) throws IOException {
         projectId = projectId.replace("__", ":").replace("_", ".");
 
         QueryRequest qr = new QueryRequest()
@@ -677,6 +678,9 @@ public class BQSupportFuncts {
                 .setMaximumBytesBilled(maxBillingBytes);
         if (dataSet != null) {
             qr.setDefaultDataset(new DatasetReference().setDatasetId(dataSet).setProjectId(projectId));
+        }
+        if (maxResults != null) {
+            qr.setMaxResults(maxResults);
         }
 
         return bigquery.jobs().query(querySql, qr)

--- a/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
@@ -653,9 +653,9 @@ public class BQSupportFuncts {
         return properties;
     }
 
-    public static Job runQuery(Bigquery bigquery, String projectId,
-                               String querySql, String dataSet, Boolean useLegacySql,
-                               Long maxBillingBytes, Long queryTimeoutMs) throws IOException {
+    public static QueryResponse runSyncQuery(Bigquery bigquery, String projectId,
+                                              String querySql, String dataSet, Boolean useLegacySql,
+                                              Long maxBillingBytes, Long queryTimeoutMs) throws IOException {
         projectId = projectId.replace("__", ":").replace("_", ".");
 
         QueryRequest qr = new QueryRequest()
@@ -666,13 +666,9 @@ public class BQSupportFuncts {
             qr.setDefaultDataset(new DatasetReference().setDatasetId(dataSet).setProjectId(projectId));
         }
 
-        String jobId = bigquery.jobs().query(querySql, qr)
+        return bigquery.jobs().query(querySql, qr)
                 .setProjectId(projectId)
-                .execute()
-                .getJobReference()
-                .getJobId();
-
-        return bigquery.jobs().get(projectId, jobId).execute();
+                .execute();
     }
 
 

--- a/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
@@ -665,6 +665,25 @@ public class BQSupportFuncts {
         return properties;
     }
 
+    /**
+     * Run a query using the synchronous jobs.query() BigQuery endpoint.
+     *
+     * @param bigquery The BigQuery API wrapper
+     * @param projectId
+     * @param querySql The SQL to execute
+     * @param dataSet default dataset, can be null
+     * @param useLegacySql
+     * @param maxBillingBytes Maximum bytes that the API will allow to bill
+     * @param queryTimeoutMs The timeout at which point the API will return with an incomplete result
+     *                         NOTE: this does _not_ mean the query fails, just we have to get the results async
+     * @param maxResults The maximum number of rows to return with the synchronous response
+     *                     Can be null for no max, but the API always has a 10MB limit
+     *                     If more results exist, we need to fetch them in subsequent API requests.
+     *
+     * @return A [QueryResponse] with the results of the query, may be incomplete, may not have all rows.
+     *
+     * @throws IOException
+     */
     static QueryResponse runSyncQuery(Bigquery bigquery, String projectId,
                                               String querySql, String dataSet, Boolean useLegacySql,
                                               Long maxBillingBytes, Long queryTimeoutMs, Long maxResults

--- a/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
@@ -653,6 +653,29 @@ public class BQSupportFuncts {
         return properties;
     }
 
+    public static Job runQuery(Bigquery bigquery, String projectId,
+                               String querySql, String dataSet, Boolean useLegacySql,
+                               Long maxBillingBytes, Long queryTimeoutMs) throws IOException {
+        projectId = projectId.replace("__", ":").replace("_", ".");
+
+        QueryRequest qr = new QueryRequest()
+                .setTimeoutMs(queryTimeoutMs)
+                .setUseLegacySql(useLegacySql);
+                // TODO: we should be able to set maxbillingGBs here, but this API currenlty does not support it
+        if (dataSet != null) {
+            qr.setDefaultDataset(new DatasetReference().setDatasetId(dataSet).setProjectId(projectId));
+        }
+
+        String jobId = bigquery.jobs().query(querySql, qr)
+                .setProjectId(projectId)
+                .execute()
+                .getJobReference()
+                .getJobId();
+
+        return bigquery.jobs().get(projectId, jobId).execute();
+    }
+
+
     /**
      * Starts a new query in async mode.
      *

--- a/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
@@ -661,8 +661,8 @@ public class BQSupportFuncts {
         QueryRequest qr = new QueryRequest()
                 .setTimeoutMs(queryTimeoutMs)
                 .setQuery(querySql)
-                .setUseLegacySql(useLegacySql);
-                // TODO: we should be able to set maxbillingGBs here, but this API currently does not support it
+                .setUseLegacySql(useLegacySql)
+                .setMaximumBytesBilled(maxBillingBytes);
         if (dataSet != null) {
             qr.setDefaultDataset(new DatasetReference().setDatasetId(dataSet).setProjectId(projectId));
         }

--- a/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
@@ -660,6 +660,7 @@ public class BQSupportFuncts {
 
         QueryRequest qr = new QueryRequest()
                 .setTimeoutMs(queryTimeoutMs)
+                .setQuery(querySql)
                 .setUseLegacySql(useLegacySql);
                 // TODO: we should be able to set maxbillingGBs here, but this API currenlty does not support it
         if (dataSet != null) {

--- a/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
@@ -653,7 +653,7 @@ public class BQSupportFuncts {
         return properties;
     }
 
-    public static QueryResponse runSyncQuery(Bigquery bigquery, String projectId,
+    static QueryResponse runSyncQuery(Bigquery bigquery, String projectId,
                                               String querySql, String dataSet, Boolean useLegacySql,
                                               Long maxBillingBytes, Long queryTimeoutMs) throws IOException {
         projectId = projectId.replace("__", ":").replace("_", ".");
@@ -662,7 +662,7 @@ public class BQSupportFuncts {
                 .setTimeoutMs(queryTimeoutMs)
                 .setQuery(querySql)
                 .setUseLegacySql(useLegacySql);
-                // TODO: we should be able to set maxbillingGBs here, but this API currenlty does not support it
+                // TODO: we should be able to set maxbillingGBs here, but this API currently does not support it
         if (dataSet != null) {
             qr.setDefaultDataset(new DatasetReference().setDatasetId(dataSet).setProjectId(projectId));
         }

--- a/src/test/java/BQJDBC/QueryResultTest/BQForwardOnlyResultSetFunctionTest.java
+++ b/src/test/java/BQJDBC/QueryResultTest/BQForwardOnlyResultSetFunctionTest.java
@@ -51,9 +51,11 @@ public class BQForwardOnlyResultSetFunctionTest {
     private static java.sql.ResultSet Result = null;
 
     Logger logger = Logger.getLogger(BQForwardOnlyResultSetFunctionTest.class.getName());
+    private Integer maxRows = null;
 
     @Test
     public void ChainedCursorFunctionTest() {
+        this.QueryLoad();
         this.logger.info("ChainedFunctionTest");
         try {
             Assert.assertTrue(BQForwardOnlyResultSetFunctionTest.Result.next());
@@ -100,6 +102,7 @@ public class BQForwardOnlyResultSetFunctionTest {
 
     @Test
     public void databaseMetaDataGetTables() {
+        this.QueryLoad();
         ResultSet result = null;
         try {
             result = con.getMetaData().getColumns(null, "starschema_net__clouddb", "OUTLET_LOOKUP", null);
@@ -135,6 +138,7 @@ public class BQForwardOnlyResultSetFunctionTest {
      */
     @Test
     public void isClosedValidtest() {
+        this.QueryLoad();
         try {
             Assert.assertEquals(true, BQForwardOnlyResultSetFunctionTest.con.isValid(0));
         } catch (SQLException e) {
@@ -183,7 +187,7 @@ public class BQForwardOnlyResultSetFunctionTest {
         NewConnection(true);
     }
 
-     void NewConnection(boolean useLegacySql) {
+    void NewConnection(boolean useLegacySql) {
 
          this.logger.info("Testing the JDBC driver");
          try {
@@ -201,9 +205,6 @@ public class BQForwardOnlyResultSetFunctionTest {
          }
          this.logger.info(((BQConnection) BQForwardOnlyResultSetFunctionTest.con)
                  .getURLPART());
-         if (useLegacySql) {
-            this.QueryLoad();
-        }
     }
 
     // Comprehensive Tests:
@@ -219,6 +220,9 @@ public class BQForwardOnlyResultSetFunctionTest {
             Statement stmt = BQForwardOnlyResultSetFunctionTest.con
                     .createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
             stmt.setQueryTimeout(500);
+            if (this.maxRows != null) {
+                stmt.setMaxRows(this.maxRows);
+            }
             BQForwardOnlyResultSetFunctionTest.Result = stmt.executeQuery(sql);
         } catch (SQLException e) {
             this.logger.error("SQLexception" + e.toString());
@@ -242,6 +246,7 @@ public class BQForwardOnlyResultSetFunctionTest {
 
     @Test
     public void TestResultIndexOutofBound() {
+        this.QueryLoad();
         try {
             this.logger.debug(BQForwardOnlyResultSetFunctionTest.Result.getBoolean(99));
         } catch (SQLException e) {
@@ -253,6 +258,7 @@ public class BQForwardOnlyResultSetFunctionTest {
 
     @Test
     public void TestResultSetFirst() {
+        this.QueryLoad();
         try {
 //            Assert.assertTrue(BQForwardOnlyResultSetFunctionTest.Result.first());
             Result.next();
@@ -265,6 +271,7 @@ public class BQForwardOnlyResultSetFunctionTest {
 
     @Test
     public void TestResultSetgetBoolean() {
+        this.QueryLoad();
         try {
             Assert.assertTrue(Result.next());
             Assert.assertEquals(Boolean.parseBoolean("42"),
@@ -277,6 +284,7 @@ public class BQForwardOnlyResultSetFunctionTest {
 
     @Test
     public void TestResultSetgetFloat() {
+        this.QueryLoad();
         try {
             Assert.assertTrue(Result.next());
             Assert.assertEquals(new Float(42),
@@ -289,6 +297,7 @@ public class BQForwardOnlyResultSetFunctionTest {
 
     @Test
     public void TestResultSetgetInteger() {
+        this.QueryLoad();
         try {
             Assert.assertTrue(Result.next());
             Assert.assertEquals(42, BQForwardOnlyResultSetFunctionTest.Result.getInt(2));
@@ -300,7 +309,7 @@ public class BQForwardOnlyResultSetFunctionTest {
 
     @Test
     public void TestResultSetgetRow() {
-
+        this.QueryLoad();
         try {
             Assert.assertTrue(Result.next());
             BQForwardOnlyResultSetFunctionTest.Result.getRow();
@@ -311,6 +320,7 @@ public class BQForwardOnlyResultSetFunctionTest {
 
     @Test
     public void TestResultSetgetString() {
+        this.QueryLoad();
         try {
             Assert.assertTrue(Result.next());
             Assert.assertEquals("you",
@@ -322,7 +332,14 @@ public class BQForwardOnlyResultSetFunctionTest {
     }
 
     @Test
+    public void TestResultSetNextWithLimitedRows() {
+        this.maxRows = 2;
+        TestResultSetNext();
+    }
+
+    @Test
     public void TestResultSetNext() {
+        this.QueryLoad();
         try {
 //            Assert.assertTrue(BQForwardOnlyResultSetFunctionTest.Result.first());
             Assert.assertTrue(BQForwardOnlyResultSetFunctionTest.Result.next());
@@ -442,6 +459,11 @@ public class BQForwardOnlyResultSetFunctionTest {
         SimpleDateFormat dateDateFormat = new SimpleDateFormat("yyyy-MM-dd");
         Date parsedDateDate = new java.sql.Date(dateDateFormat.parse("2011-04-03").getTime());
         Assert.assertEquals(parsedDateDate, result.getObject(4));
+    }
+
+    @Test
+    public void testResultsWithLimitedRows() {
+
     }
 
 }

--- a/src/test/java/BQJDBC/QueryResultTest/BQForwardOnlyResultSetFunctionTest.java
+++ b/src/test/java/BQJDBC/QueryResultTest/BQForwardOnlyResultSetFunctionTest.java
@@ -461,9 +461,4 @@ public class BQForwardOnlyResultSetFunctionTest {
         Assert.assertEquals(parsedDateDate, result.getObject(4));
     }
 
-    @Test
-    public void testResultsWithLimitedRows() {
-
-    }
-
 }

--- a/src/test/java/BQJDBC/QueryResultTest/CancelTest.java
+++ b/src/test/java/BQJDBC/QueryResultTest/CancelTest.java
@@ -29,6 +29,8 @@ public class CancelTest {
     public void setup() throws SQLException, IOException {
         String url = BQSupportFuncts.constructUrlFromPropertiesFile(BQSupportFuncts
                 .readFromPropFile(getClass().getResource("/installedaccount.properties").getFile()), true, null);
+        // this test relies on async to know when to attempt the cancel
+        url += "&useQueryApi=false";
         this.bq = new BQConnection(url, new Properties());
     }
 

--- a/src/test/java/BQJDBC/QueryResultTest/QueryResultTest.java
+++ b/src/test/java/BQJDBC/QueryResultTest/QueryResultTest.java
@@ -471,7 +471,49 @@ public class QueryResultTest {
     }
 
     @Test
+    public void QueryResultTestAsyncQuery() {
+        NewConnection("&useQueryApi=false");
+        final String sql = "SELECT STRING(ROUND(weight_pounds))  FROM publicdata:samples.natality GROUP BY 1 ORDER BY 1 DESC LIMIT 10;";
+        String[][] expectation = new String[][]{ {
+                "9.000000",
+                "8.000000",
+                "7.000000",
+                "6.000000",
+                "5.000000",
+                "4.000000",
+                "3.000000",
+                "2.000000",
+                "18.000000",
+                "17.000000"}};
+
+        this.logger.info("Running query:" + sql);
+
+        java.sql.ResultSet Result = null;
+        try {
+            Result = QueryResultTest.con.createStatement().executeQuery(sql);
+        } catch (SQLException e) {
+            this.logger.error("SQLexception" + e.toString());
+            Assert.fail("SQLException" + e.toString());
+        }
+        Assert.assertNotNull(Result);
+
+        HelperFunctions.printer(expectation);
+
+        try {
+            Assert.assertTrue(
+                    "Comparing failed in the String[][] array",
+                    this.comparer(expectation,
+                            BQSupportMethods.GetQueryResult(Result)));
+        } catch (SQLException e) {
+            this.logger.error("SQLexception" + e.toString());
+            Assert.fail(e.toString());
+        }
+    }
+
+
+    @Test
     public void QueryResultTestSyncQuery() {
+        // sync is the default, but let's test it explicitly declared anyway
         NewConnection("&useQueryApi=true");
         final String sql = "SELECT STRING(ROUND(weight_pounds))  FROM publicdata:samples.natality GROUP BY 1 ORDER BY 1 DESC LIMIT 10;";
         String[][] expectation = new String[][]{ {

--- a/src/test/java/BQJDBC/QueryResultTest/QueryResultTest.java
+++ b/src/test/java/BQJDBC/QueryResultTest/QueryResultTest.java
@@ -24,19 +24,18 @@
  */
 package BQJDBC.QueryResultTest;
 
-import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-
 import junit.framework.Assert;
 import net.starschema.clouddb.jdbc.BQConnection;
 import net.starschema.clouddb.jdbc.BQSupportFuncts;
 import net.starschema.clouddb.jdbc.BQSupportMethods;
-
 import org.apache.log4j.Logger;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 //import net.starschema.clouddb.bqjdbc.logging.Logger;
 
 /**
@@ -74,19 +73,21 @@ public class QueryResultTest {
      * Makes a new Bigquery Connection to Hardcoded URL and gives back the
      * Connection to static con member.
      */
-    @Before
-    public void NewConnection() {
+    public void NewConnection(String extraUrl) {
         try {
             if (QueryResultTest.con == null || !QueryResultTest.con.isValid(0)) {
 
                 this.logger.info("Testing the JDBC driver");
                 try {
                     Class.forName("net.starschema.clouddb.jdbc.BQDriver");
+                    String jdbcUrl = BQSupportFuncts
+                            .constructUrlFromPropertiesFile(BQSupportFuncts
+                                    .readFromPropFile(getClass().getResource("/serviceaccount.properties").getFile()));
+                    if (extraUrl != null) {
+                        jdbcUrl += extraUrl;
+                    }
                     QueryResultTest.con = DriverManager
-                            .getConnection(
-                                    BQSupportFuncts
-                                            .constructUrlFromPropertiesFile(BQSupportFuncts
-                                                    .readFromPropFile(getClass().getResource("/serviceaccount.properties").getFile())),
+                            .getConnection(jdbcUrl,
                                     BQSupportFuncts
                                             .readFromPropFile(getClass().getResource("/serviceaccount.properties").getFile()));
                 } catch (Exception e) {
@@ -100,6 +101,11 @@ public class QueryResultTest {
             // TODO Auto-generated catch block
             e.printStackTrace();
         }
+    }
+
+    @Before
+    public void NewConnection() {
+        NewConnection(null);
     }
 
     @Test
@@ -461,6 +467,47 @@ public class QueryResultTest {
         } catch (SQLException e) {
             e.printStackTrace();
             Assert.fail();
+        }
+    }
+
+    @Test
+    public void QueryResultTestSyncQuery() {
+        NewConnection("useQueryApi=true");
+        final String sql = "SELECT STRING(ROUND(weight_pounds))  FROM publicdata:samples.natality GROUP BY 1 ORDER BY 1 DESC LIMIT 10;";
+        String[][] expectation = new String[][]{ {
+                "9.000000",
+                "8.000000",
+                "7.000000",
+                "6.000000",
+                "5.000000",
+                "4.000000",
+                "3.000000",
+                "2.000000",
+                "18.000000",
+                "17.000000"}};
+
+        this.logger.info("Test Tokyo number: 1");
+        this.logger.info("Running query:" + sql);
+
+        java.sql.ResultSet Result = null;
+        try {
+            Result = QueryResultTest.con.createStatement().executeQuery(sql);
+        } catch (SQLException e) {
+            this.logger.error("SQLexception" + e.toString());
+            Assert.fail("SQLException" + e.toString());
+        }
+        Assert.assertNotNull(Result);
+
+        HelperFunctions.printer(expectation);
+
+        try {
+            Assert.assertTrue(
+                    "Comparing failed in the String[][] array",
+                    this.comparer(expectation,
+                            BQSupportMethods.GetQueryResult(Result)));
+        } catch (SQLException e) {
+            this.logger.error("SQLexception" + e.toString());
+            Assert.fail(e.toString());
         }
     }
 

--- a/src/test/java/BQJDBC/QueryResultTest/QueryResultTest.java
+++ b/src/test/java/BQJDBC/QueryResultTest/QueryResultTest.java
@@ -486,7 +486,6 @@ public class QueryResultTest {
                 "18.000000",
                 "17.000000"}};
 
-        this.logger.info("Test Tokyo number: 1");
         this.logger.info("Running query:" + sql);
 
         java.sql.ResultSet Result = null;

--- a/src/test/java/BQJDBC/QueryResultTest/QueryResultTest.java
+++ b/src/test/java/BQJDBC/QueryResultTest/QueryResultTest.java
@@ -75,7 +75,7 @@ public class QueryResultTest {
      */
     public void NewConnection(String extraUrl) {
         try {
-            if (QueryResultTest.con == null || !QueryResultTest.con.isValid(0)) {
+            if (QueryResultTest.con == null || !QueryResultTest.con.isValid(0) || extraUrl != null) {
 
                 this.logger.info("Testing the JDBC driver");
                 try {
@@ -472,7 +472,7 @@ public class QueryResultTest {
 
     @Test
     public void QueryResultTestSyncQuery() {
-        NewConnection("useQueryApi=true");
+        NewConnection("&useQueryApi=true");
         final String sql = "SELECT STRING(ROUND(weight_pounds))  FROM publicdata:samples.natality GROUP BY 1 ORDER BY 1 DESC LIMIT 10;";
         String[][] expectation = new String[][]{ {
                 "9.000000",


### PR DESCRIPTION
Had to do a bit of refactoring because parts of the code assume they have a BigQuery API `GetQueryResultsResponse` object. Instead, we need to have those parts of the code take a list of rows and a schema, so that when we get all the rows we need back from the synchronous API, which will be very frequently true since the limit there is 10MB, we don't want to have to go fetch more rows from BQ.