### PR TITLE
OAuth 2.0 Access Token Authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,11 @@
       <version>v2-rev431-1.25.0</version>
     </dependency>
     <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-iamcredentials</artifactId>
+      <version>v1-rev66-1.25.0</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.8.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -154,5 +154,5 @@
     </plugins>
     <finalName>${project.artifactId}-${project.version}-thin</finalName>
   </build>
-  <version>1.10.1</version>
+  <version>1.11.0</version>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -154,5 +154,5 @@
     </plugins>
     <finalName>${project.artifactId}-${project.version}-thin</finalName>
   </build>
-  <version>1.10.0</version>
+  <version>1.10.1</version>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -149,5 +149,5 @@
     </plugins>
     <finalName>${project.artifactId}-${project.version}-thin</finalName>
   </build>
-  <version>1.9.6</version>
+  <version>1.9.7</version>
 </project>

--- a/src/main/java/net/starschema/clouddb/cmdlineverification/Oauth2Bigquery.java
+++ b/src/main/java/net/starschema/clouddb/cmdlineverification/Oauth2Bigquery.java
@@ -355,6 +355,17 @@ public class Oauth2Bigquery {
         return bigquery;
     }
 
+    /**
+     * This function gives back a valid OAuth 2.0 access token from service account credentials
+     *
+     * @param serviceaccountemail
+     * @param keypath
+     * @param password
+     * @param jsonAuthContents
+     * @return Valid OAuth 2.0 access token
+     * @throws GeneralSecurityException
+     * @throws IOException
+     */
     public static String generateAccessToken(String serviceaccountemail,
                                              String keypath,
                                              String password,

--- a/src/main/java/net/starschema/clouddb/cmdlineverification/Oauth2Bigquery.java
+++ b/src/main/java/net/starschema/clouddb/cmdlineverification/Oauth2Bigquery.java
@@ -326,16 +326,7 @@ public class Oauth2Bigquery {
                                                String password,
                                                String userAgent,
                                                String jsonAuthContents, Integer readTimeout, Integer connectTimeout) throws GeneralSecurityException, IOException {
-        GoogleCredential credential;
-        // Determine which keyfile we are trying to authenticate with.
-        if (jsonAuthContents != null) {
-            credential = Oauth2Bigquery.createJsonCredential(jsonAuthContents, false);
-        } else if (Pattern.matches(".*\\.json$", keypath)) {
-            // For backwards compat: this is no longer the preferred path for JSON (better to use [jsonAuthContents]
-            credential = Oauth2Bigquery.createJsonCredentialFromKeyfile(keypath, false);
-        } else {
-            credential = Oauth2Bigquery.createP12Credential(serviceaccountemail, keypath, password, false);
-        }
+        GoogleCredential credential = createCredential(serviceaccountemail, keypath, password, jsonAuthContents, false);
 
         logger.debug("Authorizied?");
 
@@ -371,16 +362,7 @@ public class Oauth2Bigquery {
                                              String keypath,
                                              String password,
                                              String jsonAuthContents) throws GeneralSecurityException, IOException {
-        GoogleCredential credential;
-        // Determine which keyfile we are trying to authenticate with.
-        if (jsonAuthContents != null) {
-            credential = Oauth2Bigquery.createJsonCredential(jsonAuthContents, false);
-        } else if (Pattern.matches(".*\\.json$", keypath)) {
-            // For backwards compat: this is no longer the preferred path for JSON (better to use [jsonAuthContents]
-            credential = Oauth2Bigquery.createJsonCredentialFromKeyfile(keypath, false);
-        } else {
-            credential = Oauth2Bigquery.createP12Credential(serviceaccountemail, keypath, password, false);
-        }
+        GoogleCredential credential = createCredential(serviceaccountemail, keypath, password, jsonAuthContents, true);
         HttpRequestTimeoutInitializer httpRequestInitializer = new HttpRequestTimeoutInitializer(credential);
 
         IAMCredentials.Builder builder = new IAMCredentials.Builder(
@@ -399,6 +381,24 @@ public class Oauth2Bigquery {
         generateAccessToken = iamCredentials.projects().serviceAccounts().generateAccessToken(name, request);
         GenerateAccessTokenResponse response = generateAccessToken.execute();
         return response.getAccessToken();
+    }
+
+    private static GoogleCredential createCredential(String serviceaccountemail,
+                                                     String keypath,
+                                                     String password,
+                                                     String jsonAuthContents,
+                                                     Boolean forTokenGeneration) throws GeneralSecurityException, IOException {
+        GoogleCredential credential;
+        // Determine which keyfile we are trying to authenticate with.
+        if (jsonAuthContents != null) {
+            credential = Oauth2Bigquery.createJsonCredential(jsonAuthContents, forTokenGeneration);
+        } else if (Pattern.matches(".*\\.json$", keypath)) {
+            // For backwards compat: this is no longer the preferred path for JSON (better to use [jsonAuthContents]
+            credential = Oauth2Bigquery.createJsonCredentialFromKeyfile(keypath, forTokenGeneration);
+        } else {
+            credential = Oauth2Bigquery.createP12Credential(serviceaccountemail, keypath, password, forTokenGeneration);
+        }
+        return credential;
     }
 
     // Helper function to generate scopes for credential files

--- a/src/main/java/net/starschema/clouddb/cmdlineverification/Oauth2Bigquery.java
+++ b/src/main/java/net/starschema/clouddb/cmdlineverification/Oauth2Bigquery.java
@@ -326,7 +326,7 @@ public class Oauth2Bigquery {
                                                String password,
                                                String userAgent,
                                                String jsonAuthContents, Integer readTimeout, Integer connectTimeout) throws GeneralSecurityException, IOException {
-        GoogleCredential credential = createCredential(serviceaccountemail, keypath, password, jsonAuthContents, false);
+        GoogleCredential credential = createServiceAccountCredential(serviceaccountemail, keypath, password, jsonAuthContents, false);
 
         logger.debug("Authorizied?");
 
@@ -362,7 +362,7 @@ public class Oauth2Bigquery {
                                              String keypath,
                                              String password,
                                              String jsonAuthContents) throws GeneralSecurityException, IOException {
-        GoogleCredential credential = createCredential(serviceaccountemail, keypath, password, jsonAuthContents, true);
+        GoogleCredential credential = createServiceAccountCredential(serviceaccountemail, keypath, password, jsonAuthContents, true);
         HttpRequestTimeoutInitializer httpRequestInitializer = new HttpRequestTimeoutInitializer(credential);
 
         IAMCredentials.Builder builder = new IAMCredentials.Builder(
@@ -383,11 +383,11 @@ public class Oauth2Bigquery {
         return response.getAccessToken();
     }
 
-    private static GoogleCredential createCredential(String serviceaccountemail,
-                                                     String keypath,
-                                                     String password,
-                                                     String jsonAuthContents,
-                                                     Boolean forTokenGeneration) throws GeneralSecurityException, IOException {
+    private static GoogleCredential createServiceAccountCredential(String serviceaccountemail,
+                                                                   String keypath,
+                                                                   String password,
+                                                                   String jsonAuthContents,
+                                                                   Boolean forTokenGeneration) throws GeneralSecurityException, IOException {
         GoogleCredential credential;
         // Determine which keyfile we are trying to authenticate with.
         if (jsonAuthContents != null) {

--- a/src/main/java/net/starschema/clouddb/cmdlineverification/Oauth2Bigquery.java
+++ b/src/main/java/net/starschema/clouddb/cmdlineverification/Oauth2Bigquery.java
@@ -258,7 +258,7 @@ public class Oauth2Bigquery {
     private static GoogleCredential createP12Credential(String serviceaccountemail,
                                                          String keypath,
                                                          String password,
-                                                         Boolean forTokenGeneration) throws GeneralSecurityException, IOException {
+                                                         boolean forTokenGeneration) throws GeneralSecurityException, IOException {
         logger.debug("Authorizing with service account.");
         GoogleCredential.Builder builder = new GoogleCredential.Builder()
                 .setTransport(CmdlineUtils.getHttpTransport())
@@ -287,7 +287,7 @@ public class Oauth2Bigquery {
      * @throws GeneralSecurityException
      * @throws IOException
      */
-    private static GoogleCredential createJsonCredential(String jsonAuthContents, Boolean forTokenGeneration) throws GeneralSecurityException, IOException {
+    private static GoogleCredential createJsonCredential(String jsonAuthContents, boolean forTokenGeneration) throws GeneralSecurityException, IOException {
         logger.debug("Authorizing with service account.");
         // For .json load the key via credential.fromStream
         InputStream stringStream = new ByteArrayInputStream(jsonAuthContents.getBytes());
@@ -302,7 +302,7 @@ public class Oauth2Bigquery {
      * @throws GeneralSecurityException
      * @throws IOException
      */
-    private static GoogleCredential createJsonCredentialFromKeyfile(String keypath, Boolean forTokenGeneration) throws GeneralSecurityException, IOException {
+    private static GoogleCredential createJsonCredentialFromKeyfile(String keypath, boolean forTokenGeneration) throws GeneralSecurityException, IOException {
         logger.debug("Authorizing with service account.");
         // For .json load the key via credential.fromStream
         File jsonKey = new File(keypath);
@@ -387,7 +387,7 @@ public class Oauth2Bigquery {
                                                                    String keypath,
                                                                    String password,
                                                                    String jsonAuthContents,
-                                                                   Boolean forTokenGeneration) throws GeneralSecurityException, IOException {
+                                                                   boolean forTokenGeneration) throws GeneralSecurityException, IOException {
         GoogleCredential credential;
         // Determine which keyfile we are trying to authenticate with.
         if (jsonAuthContents != null) {
@@ -402,7 +402,7 @@ public class Oauth2Bigquery {
     }
 
     // Helper function to generate scopes for credential files
-    private static List<String> GenerateScopes(Boolean forTokenGeneration){
+    private static List<String> GenerateScopes(boolean forTokenGeneration){
         List<String> scopes = new ArrayList<String>();
         if (forTokenGeneration) {
             scopes.add(BigqueryScopes.CLOUD_PLATFORM);

--- a/src/main/java/net/starschema/clouddb/cmdlineverification/Oauth2Bigquery.java
+++ b/src/main/java/net/starschema/clouddb/cmdlineverification/Oauth2Bigquery.java
@@ -65,9 +65,6 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 public class Oauth2Bigquery {
-
-    private static String servicepath = null;
-
     /**
      * Log4j logger, for debugging.
      */
@@ -198,7 +195,6 @@ public class Oauth2Bigquery {
 
         Bigquery bigquery = bqBuilder.build();
 
-        Oauth2Bigquery.servicepath = bigquery.getServicePath();
         return bigquery;
     }
 
@@ -242,7 +238,6 @@ public class Oauth2Bigquery {
 
         Bigquery bigquery = bqBuilder.build();
 
-        Oauth2Bigquery.servicepath = bigquery.getServicePath();
         return bigquery;
     }
 
@@ -352,8 +347,6 @@ public class Oauth2Bigquery {
         }
 
         Bigquery bigquery = bqBuilder.build();
-
-        Oauth2Bigquery.servicepath = bigquery.getServicePath();
 
         return bigquery;
     }
@@ -505,10 +498,6 @@ public class Oauth2Bigquery {
      */
     public static GoogleClientSecrets getClientSecrets() {
         return Oauth2Bigquery.clientSecrets;
-    }
-
-    public static String getservicepath() {
-        return Oauth2Bigquery.servicepath;
     }
 
     /**

--- a/src/main/java/net/starschema/clouddb/cmdlineverification/Oauth2Bigquery.java
+++ b/src/main/java/net/starschema/clouddb/cmdlineverification/Oauth2Bigquery.java
@@ -77,6 +77,10 @@ public class Oauth2Bigquery {
             "epiphany", "konqueror", "conkeror", "midori", "kazehakase",
             "mozilla"};
     /**
+     * Application name set on bigquery connection
+     */
+    static final String applicationName = "Starschema BigQuery JDBC Driver";
+    /**
      * Google client secrets or {@code null} before initialized in
      * {@link #authorize}.
      */
@@ -227,7 +231,7 @@ public class Oauth2Bigquery {
             CmdlineUtils.getHttpTransport(),
             CmdlineUtils.getJsonFactory(),
             httpRequestInitializer
-        ).setApplicationName("Starschema BigQuery JDBC Driver");
+        ).setApplicationName(applicationName);
 
         BigQueryRequestUserAgentInitializer requestInitializer = new BigQueryRequestUserAgentInitializer();
         requestInitializer.setOauthToken(oauthToken);
@@ -337,7 +341,7 @@ public class Oauth2Bigquery {
                 CmdlineUtils.getHttpTransport(),
                 CmdlineUtils.getJsonFactory(),
                 httpRequestInitializer)
-                .setApplicationName("Starschema BigQuery JDBC Driver");
+                .setApplicationName(applicationName);
 
         if (userAgent != null) {
             BigQueryRequestUserAgentInitializer requestInitializer = new BigQueryRequestUserAgentInitializer();
@@ -362,7 +366,7 @@ public class Oauth2Bigquery {
             CmdlineUtils.getHttpTransport(),
             CmdlineUtils.getJsonFactory(),
             httpRequestInitializer
-        ).setApplicationName("Starschema BigQuery JDBC Driver");
+        ).setApplicationName(applicationName);
 
         IAMCredentials iamCredentials = builder.build();
 

--- a/src/main/java/net/starschema/clouddb/cmdlineverification/Oauth2Bigquery.java
+++ b/src/main/java/net/starschema/clouddb/cmdlineverification/Oauth2Bigquery.java
@@ -209,7 +209,7 @@ public class Oauth2Bigquery {
      * @return Authorized Bigquery Connection via OAuth Token
      * @throws SQLException
      */
-    public static Bigquery authorizeviatoken(String oauthToken,
+    public static Bigquery authorizeViaToken(String oauthToken,
                                              String userAgent,
                                              Integer connectTimeout,
                                              Integer readTimeout) throws SQLException {

--- a/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
@@ -158,6 +158,8 @@ public class BQConnection implements Connection {
         String userKey = caseInsensitiveProps.getProperty("password");
         String userPath = caseInsensitiveProps.getProperty("path");
 
+        String oAuthAccessToken = caseInsensitiveProps.getProperty("oauthaccesstoken");
+
         // extract withServiceAccount property
         String withServiceAccountParam = caseInsensitiveProps.getProperty("withserviceaccount");
         Boolean serviceAccount = (withServiceAccountParam != null) && Boolean.parseBoolean(withServiceAccountParam);
@@ -224,7 +226,14 @@ public class BQConnection implements Connection {
                 throw new BQSQLException(e);
             }
         }
-        //let use Oauth
+        else if (oAuthAccessToken != null) {
+            try {
+                this.bigquery = Oauth2Bigquery.authorizeviatoken(oAuthAccessToken, userAgent, connectTimeout, readTimeout);
+                this.logger.info("Authorized with OAuth access token");
+            } catch (SQLException e) {
+                throw new BQSQLException(e);
+            }
+        }
         else {
             this.bigquery = Oauth2Bigquery.authorizeviainstalled(userId, userKey, userAgent);
             this.logger.info("Authorized with Oauth");

--- a/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
@@ -230,7 +230,7 @@ public class BQConnection implements Connection {
         }
         else if (oAuthAccessToken != null) {
             try {
-                this.bigquery = Oauth2Bigquery.authorizeviatoken(oAuthAccessToken, userAgent, connectTimeout, readTimeout);
+                this.bigquery = Oauth2Bigquery.authorizeViaToken(oAuthAccessToken, userAgent, connectTimeout, readTimeout);
                 this.logger.info("Authorized with OAuth access token");
             } catch (SQLException e) {
                 throw new BQSQLException(e);

--- a/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
@@ -107,6 +107,17 @@ public class BQSupportFuncts {
             } else {
                 return null;
             }
+        } else if (properties.getProperty("type").equals("oauth")) {
+            if (Password != null && ProjectId != null) {
+                forreturn = BQDriver.getURLPrefix()
+                    + URLEncoder.encode(ProjectId, "UTF-8")
+                    + (dataset != null && full ? "/" + URLEncoder.encode(dataset, "UTF-8") : "");
+                if (full) {
+                    forreturn += "?oAuthAccessToken=" + URLEncoder.encode(Password, "UTF-8");
+                }
+            } else {
+                return null;
+            }
         } else {
             return null;
         }

--- a/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
@@ -108,12 +108,13 @@ public class BQSupportFuncts {
                 return null;
             }
         } else if (properties.getProperty("type").equals("oauth")) {
-            if (Password != null && ProjectId != null) {
+            String accessToken = properties.getProperty("oauthaccesstoken");
+            if (accessToken != null && ProjectId != null) {
                 forreturn = BQDriver.getURLPrefix()
                     + URLEncoder.encode(ProjectId, "UTF-8")
                     + (dataset != null && full ? "/" + URLEncoder.encode(dataset, "UTF-8") : "");
                 if (full) {
-                    forreturn += "?oAuthAccessToken=" + URLEncoder.encode(Password, "UTF-8");
+                    forreturn += "?oAuthAccessToken=" + URLEncoder.encode(accessToken, "UTF-8");
                 }
             } else {
                 return null;

--- a/src/test/java/BQJDBC/QueryResultTest/JdbcUrlTest.java
+++ b/src/test/java/BQJDBC/QueryResultTest/JdbcUrlTest.java
@@ -134,7 +134,7 @@ public class JdbcUrlTest {
         );
 
         Properties oauthProps = getProperties("/oauthaccount.properties");
-        oauthProps.setProperty("password", accessToken);
+        oauthProps.setProperty("oauthaccesstoken", accessToken);
         String url = BQSupportFuncts.constructUrlFromPropertiesFile(oauthProps, true, null);
         BQConnection bqConn = new BQConnection(url, new Properties());
 


### PR DESCRIPTION
This adds the ability to pass in an OAuth 2.0 access token in with the jdbc url to authenticate with a url param `oAuthAccessToken=`.

In order to test this, I also added a method to get an access token from Bigquery's API using service account credentials. So the test first gets the access token, and then runs a query using that token.