### PR TITLE
Fix getString for TIMESTAMP types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,8 +133,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>8</source>
+          <target>8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -154,5 +154,5 @@
     </plugins>
     <finalName>${project.artifactId}-${project.version}-thin</finalName>
   </build>
-  <version>1.11.0</version>
+  <version>2.0.0</version>
 </project>

--- a/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
@@ -42,9 +42,12 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.sql.*;
 import java.sql.Date;
+import java.sql.*;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 
 /**
@@ -89,6 +92,10 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
     /** Cursor position which goes from -1 to FETCH_SIZE then 0 to FETCH_SIZE
      * The -1 is needed because of the while(Result.next() == true) { } iterating method*/
     private int Cursor = -1;
+
+    private final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter
+            .ofPattern("yyyy-MM-dd HH:mm:ss")
+            .withZone(ZoneId.of("UTC"));
 
     /**
      * Constructor for the forward only resultset
@@ -273,6 +280,10 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
             return null;
         }
         this.wasnull = false;
+        if (getMetaData().getColumnType(columnIndex) == Types.TIMESTAMP) {
+            Instant instant = Instant.ofEpochSecond(new BigDecimal((String) resultObject).longValue());
+            return TIMESTAMP_FORMATTER.format(instant);
+        }
         if (resultObject instanceof List || resultObject instanceof Map) {
             Object resultTransformedWithSchema = smartTransformResult(
                     resultObject,

--- a/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
@@ -94,7 +94,7 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
     private int Cursor = -1;
 
     private final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter
-            .ofPattern("yyyy-MM-dd HH:mm:ss")
+            .ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
             .withZone(ZoneId.of("UTC"));
 
     /**
@@ -281,7 +281,7 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
         }
         this.wasnull = false;
         if (getMetaData().getColumnType(columnIndex) == Types.TIMESTAMP) {
-            Instant instant = Instant.ofEpochSecond(new BigDecimal((String) resultObject).longValue());
+            Instant instant = Instant.ofEpochMilli((new BigDecimal((String) resultObject).movePointRight(3)).longValue());
             return TIMESTAMP_FORMATTER.format(instant);
         }
         if (resultObject instanceof List || resultObject instanceof Map) {

--- a/src/test/java/BQJDBC/QueryResultTest/BQForwardOnlyResultSetFunctionTest.java
+++ b/src/test/java/BQJDBC/QueryResultTest/BQForwardOnlyResultSetFunctionTest.java
@@ -373,7 +373,7 @@ public class BQForwardOnlyResultSetFunctionTest {
                 "['a', 'b', 'c'], " +
                 "[STRUCT(1 as a, 'hello' as b), STRUCT(2 as a, 'goodbye' as b)], " +
                 "STRUCT(1 as a, ['an', 'array'] as b)," +
-                "TIMESTAMP('2012-01-01 00:00:03') as t"
+                "TIMESTAMP('2012-01-01 00:00:03.032') as t"
         ;
 
         this.NewConnection(false);
@@ -407,7 +407,7 @@ public class BQForwardOnlyResultSetFunctionTest {
         Assert.assertEquals("1", mixedBagActual.get("a"));
         Assert.assertEquals(org.mortbay.util.ajax.JSON.toString(new String[]{"an", "array"}), org.mortbay.util.ajax.JSON.toString(mixedBagActual.get("b")));
 
-        Assert.assertEquals("2012-01-01 00:00:03", result.getString(5));
+        Assert.assertEquals("2012-01-01 00:00:03.032", result.getString(5));
     }
 
     @Test

--- a/src/test/java/BQJDBC/QueryResultTest/BQForwardOnlyResultSetFunctionTest.java
+++ b/src/test/java/BQJDBC/QueryResultTest/BQForwardOnlyResultSetFunctionTest.java
@@ -372,7 +372,9 @@ public class BQForwardOnlyResultSetFunctionTest {
                 "STRUCT(1 as a, 'hello' as b), " +
                 "['a', 'b', 'c'], " +
                 "[STRUCT(1 as a, 'hello' as b), STRUCT(2 as a, 'goodbye' as b)], " +
-                "STRUCT(1 as a, ['an', 'array'] as b)";
+                "STRUCT(1 as a, ['an', 'array'] as b)," +
+                "TIMESTAMP('2012-01-01 00:00:03') as t"
+        ;
 
         this.NewConnection(false);
         java.sql.ResultSet result = null;
@@ -404,6 +406,8 @@ public class BQForwardOnlyResultSetFunctionTest {
         Assert.assertEquals(2, mixedBagActual.size());
         Assert.assertEquals("1", mixedBagActual.get("a"));
         Assert.assertEquals(org.mortbay.util.ajax.JSON.toString(new String[]{"an", "array"}), org.mortbay.util.ajax.JSON.toString(mixedBagActual.get("b")));
+
+        Assert.assertEquals("2012-01-01 00:00:03", result.getString(5));
     }
 
     @Test


### PR DESCRIPTION
Also moved language compatibility to Java 8 and so bumped to 2.0...

maybe bump to 2.0 is too aggressive? But I was _not_ going to use the Java legacy Date API to do this. And it's time for this project to be on 8.

As to the bug, prior to this change, since TIMESTAMPs come back in JSON over the wire as stringified BigInts, and getString was doing nothing special to handle that, the result for `SELECT CURRENT_TIMESTAMP` was something like `"1.234932532E9"`