### PR TITLE
Add oauth token accessor to bigquery request initializer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,5 +154,5 @@
     </plugins>
     <finalName>${project.artifactId}-${project.version}-thin</finalName>
   </build>
-  <version>1.11.0</version>
+  <version>1.11.1</version>
 </project>

--- a/src/main/java/net/starschema/clouddb/cmdlineverification/Oauth2Bigquery.java
+++ b/src/main/java/net/starschema/clouddb/cmdlineverification/Oauth2Bigquery.java
@@ -597,6 +597,8 @@ public class Oauth2Bigquery {
             return this.userAgent;
         }
 
+        public String getOauthToken() {return this.oauthToken; }
+
         @Override
         public void initializeBigqueryRequest(BigqueryRequest<?> request) throws IOException {
             if (userAgent != null) {


### PR DESCRIPTION
in order to tell if a connection is using oauth, so we can check for oauth-specific 401 errors

this is similar to the user agent accessor that's on the same class.