### PR TITLE
Type parity between BQ and Starschema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,5 +154,5 @@
     </plugins>
     <finalName>${project.artifactId}-${project.version}-thin</finalName>
   </build>
-  <version>2.0.2</version>
+  <version>2.0.3</version>
 </project>

--- a/src/main/java/net/starschema/clouddb/jdbc/BQResultSetMetadata.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQResultSetMetadata.java
@@ -27,12 +27,7 @@
 
 package net.starschema.clouddb.jdbc;
 
-import java.sql.Date;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
-import java.sql.Struct;
-import java.sql.Timestamp;
+import java.sql.*;
 import java.util.List;
 
 import com.google.api.client.util.Data;
@@ -192,16 +187,24 @@ class BQResultsetMetaData implements ResultSetMetaData {
 
     /**
      * {@inheritDoc} <br>
-     * note: This Can only Return due to bigquery:<br>
-     * java.sql.Types.DOUBLE<br>
-     * java.sql.Types.BOOLEAN<br>
-     * java.sql.Types.BIGINT<br>
-     * java.sql.Types.VARCHAR<br>
-     * java.sql.Types.TIMESTAMP<br>
-     * java.sql.Types.DATE<br>
-     * java.sql.Types.NUMERIC<br>
-     * java.sql.Types.RECORD<br>
-     * java.sql.Types.STRUCT<br>
+     * note: see below for BQ type => Java type enum<br>
+     * INTEGER => java.sql.Types.BIGINT<br>
+     * NUMERIC => java.sql.Types.NUMERIC<br>
+     * FLOAT => java.sql.Types.DOUBLE<br>
+     * BOOLEAN => java.sql.Types.BOOLEAN<br>
+     * STRING => java.sql.Types.VARCHAR<br>
+     * BYTES => java.sql.Types.VARCHAR<br>
+     * DATE => java.sql.Types.DATE<br>
+     * DATETIME => java.sql.Types.TIMESTAMP<br>
+     * TIME => java.sql.Types.TIME<br>
+     * TIMESTAMP => java.sql.Types.TIMESTAMP<br>
+     * ARRAY => unsupported<br>
+     * STRUCT => java.sql.Types.STRUCT<br>
+     * GEOGRAPHY => unsupported<br>
+     *
+     * If making changes to this method, please ensure that these types stay 1:1 with the types listed here:
+     *   https://cloud.google.com/bigquery/data-types
+     *   https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types
      * */
     @Override
     public int getColumnType(int column) throws SQLException {
@@ -246,6 +249,14 @@ class BQResultsetMetaData implements ResultSetMetaData {
 
         if (Columntype.equals("NUMERIC")) {
             return java.sql.Types.NUMERIC;
+        }
+
+        if (Columntype.equals("TIME")) {
+            return Types.TIME;
+        }
+
+        if (Columntype.equals("BYTES")) {
+            return Types.VARCHAR;
         }
 
         if (Columntype.equals("RECORD") || Columntype.equals("STRUCT")) {

--- a/src/test/java/BQJDBC/QueryResultTest/PreparedStatementTests.java
+++ b/src/test/java/BQJDBC/QueryResultTest/PreparedStatementTests.java
@@ -158,7 +158,9 @@ public class PreparedStatementTests {
                 "SELECT CAST(CURRENT_TIMESTAMP() AS TIMESTAMP)",
                 "SELECT CAST(CURRENT_DATE() AS DATE)",
                 "SELECT CAST('1' AS NUMERIC)",
-                "SELECT CAST('1' AS DATETIME)"
+                "SELECT CAST('1' AS DATETIME)",
+                "SELECT CAST('1' AS TIME)",
+                "SELECT CAST('test' AS BYTES)"
         };
         final int[] expectedType = new int[]{
                 java.sql.Types.DOUBLE,
@@ -169,6 +171,8 @@ public class PreparedStatementTests {
                 java.sql.Types.DATE,
                 java.sql.Types.NUMERIC,
                 java.sql.Types.TIMESTAMP,
+                java.sql.Types.TIME,
+                java.sql.Types.VARCHAR
         };
 
         for (int i = 0; i < queries.length; i ++) {


### PR DESCRIPTION
Add `TIME` and `BYTES` as supported types. Also add full list of BQ types for reference. 