### PR TITLE
Don't include querySql in query execution error message

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,5 +154,5 @@
     </plugins>
     <finalName>${project.artifactId}-${project.version}-thin</finalName>
   </build>
-  <version>2.1.0</version>
+  <version>2.1.1</version>
 </project>

--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
@@ -170,7 +170,8 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
                 referencedJob = startQuery(querySql, unlimitedBillingBytes);
             }
         } catch (IOException e) {
-            throw new BQSQLException("Something went wrong creating the query: " + querySql, e);
+            // For the synchronous path, this is the place where the user will encounter errors in their SQL.
+            throw new BQSQLException("Query execution failed: ", e);
         }
 
         try {


### PR DESCRIPTION
Now, with the synchronous route, this is the place where users see issues with their SQL in the form of exceptions, so we should not muddy it up with the whole querySql the way the previous version of the code did.