### PR TITLE
Fix issue with the sync bq api and connection close

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,5 +154,5 @@
     </plugins>
     <finalName>${project.artifactId}-${project.version}-thin</finalName>
   </build>
-  <version>2.1.1</version>
+  <version>2.1.2</version>
 </project>

--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
@@ -135,21 +135,12 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
         querySql = parser.parse();
         try {
             if (this.connection.shouldUseQueryApi()) {
-                QueryResponse qr = BQSupportFuncts.runSyncQuery(
-                        this.connection.getBigquery(),
-                        this.ProjectId,
-                        querySql,
-                        connection.getDataSet(),
-                        this.connection.getUseLegacySql(),
-                        !unlimitedBillingBytes ? this.connection.getMaxBillingBytes() : null,
-                        SYNC_TIMEOUT_MILLIS, // we need this to respond fast enough to avoid any socket timeouts
-                        (long) getMaxRows()
-                );
+                QueryResponse qr = runSyncQuery(querySql, unlimitedBillingBytes);
                 boolean fetchedAll = qr.getJobComplete() && qr.getTotalRows() != null &&
                         (qr.getTotalRows().equals(BigInteger.ZERO) ||
                                 (qr.getRows() != null && qr.getTotalRows().equals(BigInteger.valueOf(qr.getRows().size()))));
                 // Don't look up the job if we have nothing else we need to do
-                referencedJob = fetchedAll ?
+                referencedJob = fetchedAll || this.connection.isClosed() ?
                         null :
                         this.connection.getBigquery().jobs().get(this.ProjectId, qr.getJobReference().getJobId()).execute();
                 if (qr.getJobComplete()) {
@@ -233,6 +224,20 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
         this.cancel();
         throw new BQSQLException(
                 "Query run took more than the specified timeout");
+    }
+
+    /** wrapper that exists for tests to override */
+    protected QueryResponse runSyncQuery(String querySql, boolean unlimitedBillingBytes) throws IOException, SQLException {
+        return BQSupportFuncts.runSyncQuery(
+                this.connection.getBigquery(),
+                this.ProjectId,
+                querySql,
+                connection.getDataSet(),
+                this.connection.getUseLegacySql(),
+                !unlimitedBillingBytes ? this.connection.getMaxBillingBytes() : null,
+                SYNC_TIMEOUT_MILLIS, // we need this to respond fast enough to avoid any socket timeouts
+                (long) getMaxRows()
+        );
     }
 
     /**

--- a/src/test/java/BQJDBC/QueryResultTest/CancelTest.java
+++ b/src/test/java/BQJDBC/QueryResultTest/CancelTest.java
@@ -1,15 +1,16 @@
 package BQJDBC.QueryResultTest;
 
 import com.google.api.services.bigquery.model.Job;
+import com.google.api.services.bigquery.model.QueryResponse;
 import net.starschema.clouddb.jdbc.BQConnection;
 import net.starschema.clouddb.jdbc.BQStatement;
 import net.starschema.clouddb.jdbc.BQSupportFuncts;
 import org.junit.After;
-import org.junit.Before;
 
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Properties;
+import java.util.Random;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -22,16 +23,17 @@ import static junit.framework.Assert.assertTrue;
  */
 public class CancelTest {
 
-    private BQConnection bq;
     private Throwable diedWith;
 
-    @Before
-    public void setup() throws SQLException, IOException {
+    private BQConnection conn(boolean useQueryApi)  throws SQLException, IOException {
         String url = BQSupportFuncts.constructUrlFromPropertiesFile(BQSupportFuncts
                 .readFromPropFile(getClass().getResource("/installedaccount.properties").getFile()), true, null);
-        // this test relies on async to know when to attempt the cancel
-        url += "&useQueryApi=false";
-        this.bq = new BQConnection(url, new Properties());
+        url += "&useLegacySql=false";
+        if (!useQueryApi) {
+            // this test relies on async to know when to attempt the cancel
+            url += "&useQueryApi=false";
+        }
+        return new BQConnection(url, new Properties());
     }
 
     @After
@@ -48,12 +50,25 @@ public class CancelTest {
                 thisTest.diedWith = ex;
             }
         };
-
         Runnable background = new Runnable() {
             @Override
             public void run() {
                 try {
-                    stmt.executeQuery("select * from publicdata:samples.shakespeare limit 712");
+                    Random rand = new Random();
+                    int limit = rand.nextInt(1000) + 1;
+                    String longQuery = "WITH d as (SELECT * FROM (SELECT 391164 AS num) UNION ALL\n" +
+                            "  (SELECT 391165 AS num) UNION ALL\n" +
+                            "  (SELECT 391166 AS num) UNION ALL\n" +
+                            "  (SELECT 391167 AS num) UNION ALL\n" +
+                            "  (SELECT 391168 AS num) UNION ALL\n" +
+                            "  (SELECT 391169 AS num) UNION ALL\n" +
+                            "  (SELECT 391170 AS num) UNION ALL\n" +
+                            "  (SELECT 391171 AS num) UNION ALL\n" +
+                            "  (SELECT 391172 AS num) UNION ALL\n" +
+                            "  (SELECT 391173 AS num) UNION ALL\n" +
+                            "  (SELECT 391174 AS num))\n" +
+                            "SELECT count(*) from d d1, d d2, d d3, d d4, d d5, d d6, d d7, d d8, d d9 LIMIT " + limit;
+                    stmt.executeQuery(longQuery);
                 } catch (SQLException e) {}
             }
         };
@@ -65,19 +80,15 @@ public class CancelTest {
 
     @org.junit.Test
     public void cancelWorks() throws SQLException, InterruptedException, IOException {
+        BQConnection bq = conn(false);
         TestableBQStatement stmt = new TestableBQStatement(bq.getProjectId(), bq);
         stmt.setTestPoint();
-
         Thread backgroundThread = getAndRunBackgroundQuery(stmt);
-
         stmt.waitForTestPoint();
         assertFalse("Statement must have job", stmt.getJob() == null);
-
         // This will throw error if it tries to cancel a nonexistent job
         stmt.cancel();
-
         backgroundThread.join();
-
         // TODO: better checks that cancel worked
         // Right now, there seems to be no reliable indication in the API that a job was cancelled (status is always 'DONE'),
         // and even if the cancel signal was received the result is likely to come back successfully with all its rows.
@@ -85,36 +96,40 @@ public class CancelTest {
     }
 
     @org.junit.Test
-    public void connectionCancelWorks() throws InterruptedException {
+    public void connectionCancelWorks() throws SQLException, InterruptedException, IOException {
+        BQConnection bq = conn(false);
         final TestableBQStatement stmt1 = new TestableBQStatement(bq.getProjectId(), bq);
         final TestableBQStatement stmt2 = new TestableBQStatement(bq.getProjectId(), bq);
-
         stmt1.setTestPoint();
         stmt2.setTestPoint();
-
         Thread backgroundThread1 = getAndRunBackgroundQuery(stmt1);
         Thread backgroundThread2 = getAndRunBackgroundQuery(stmt2);
-
         stmt1.waitForTestPoint();
         stmt2.waitForTestPoint();
-
         assertTrue("Must see both running queries", bq.getNumberRunningQueries() == 2);
         assertTrue("Must not fail to cancel queries", bq.cancelRunningQueries() == 0);
-
         backgroundThread1.join();
         backgroundThread2.join();
     }
 
-    private static class TestableBQStatement extends BQStatement {
+    @org.junit.Test
+    public void connectionCloseWithSyncQueryApi() throws SQLException, InterruptedException, IOException {
+        BQConnection bq = conn(true);
+        final TestableBQStatement stmt1 = new TestableBQStatement(bq.getProjectId(), bq);
+        stmt1.setTestPoint();
+        Thread backgroundThread = getAndRunBackgroundQuery(stmt1);
+        stmt1.waitForTestPoint();
+        bq.close();
+        backgroundThread.join();
+    }
 
+    private static class TestableBQStatement extends BQStatement {
         public TestableBQStatement(String projectid, BQConnection bqConnection) {
             super(projectid, bqConnection);
         }
-
         private Condition testPoint;
         private Lock testLock;
         private boolean conditionHit = false;
-
         private void signalTestPoint() {
             if (this.testPoint == null) {
                 return;
@@ -143,6 +158,23 @@ public class CancelTest {
             } finally {
                 this.testLock.unlock();
             }
+        }
+
+        @Override
+        protected QueryResponse runSyncQuery(String querySql, boolean unlimitedBillingBytes) throws IOException, SQLException {
+            Thread signaler = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        Thread.sleep(1); // make absolutely sure we yield to the execution below so it gets through first
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException();
+                    }
+                    signalTestPoint();
+                }
+            });
+            signaler.start();
+            return super.runSyncQuery(querySql, unlimitedBillingBytes);
         }
 
         public Job startQuery(String querySql, boolean unlimitedBillingBytes) throws IOException {


### PR DESCRIPTION
Essentially, once a connection is closed, `getBigQuery` returns null, so we have to check here in case some other thread closed our connection as a way to cancel the running statements.

Then there's some finessing of the test code to get a test for this to work.