### PR TITLE
Implement basic driver support for ARRAY types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,5 +154,5 @@
     </plugins>
     <finalName>${project.artifactId}-${project.version}-thin</finalName>
   </build>
-  <version>2.1.2</version>
+  <version>2.1.3</version>
 </project>

--- a/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
@@ -164,6 +164,11 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
             return null;
         }
 
+        // for arrays, just return the string result
+        if (this.getBQResultsetMetaData().getColumnMode(columnIndex).equals("REPEATED")) {
+            return result;
+        }
+
         String Columntype = this.schema.getFields().get(columnIndex - 1).getType();
 
         try {
@@ -305,7 +310,7 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
             return null;
         }
         this.wasnull = false;
-        if (formatTimestamps && getMetaData().getColumnTypeName(columnIndex).equals("TIMESTAMP")) {
+        if (!this.getBQResultsetMetaData().getColumnMode(columnIndex).equals("REPEATED") && formatTimestamps && getMetaData().getColumnTypeName(columnIndex).equals("TIMESTAMP")) {
             Instant instant = Instant.ofEpochMilli((new BigDecimal((String) resultObject).movePointRight(3)).longValue());
             return TIMESTAMP_FORMATTER.format(instant);
         }
@@ -927,6 +932,15 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
      */
     @Override
     public ResultSetMetaData getMetaData() throws SQLException {
+        return getBQResultsetMetaData();
+    }
+
+    /**
+     * Get this ResultSet's BQForwardOnlyResultSetMetadata
+     * @return
+     * @throws SQLException
+     */
+    public BQResultsetMetaData getBQResultsetMetaData() throws SQLException {
         if (this.isClosed()) {
             throw new BQSQLException("This Resultset is Closed");
         }

--- a/src/main/java/net/starschema/clouddb/jdbc/BQResultSetMetadata.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQResultSetMetadata.java
@@ -187,6 +187,15 @@ class BQResultsetMetaData implements ResultSetMetaData {
     }
 
     /**
+     * Return the "mode" for the given columnIndex
+     * @param columnIndex
+     * @return String: will be "REPEATED" if this column is an array
+     */
+    public String getColumnMode(int columnIndex) {
+        return this.schema.getFields().get(columnIndex - 1).getMode();
+    }
+
+    /**
      * {@inheritDoc} <br>
      * note: see below for BQ type => Java type enum<br>
      * INTEGER => java.sql.Types.BIGINT<br>

--- a/src/test/java/BQJDBC/QueryResultTest/BQForwardOnlyResultSetFunctionTest.java
+++ b/src/test/java/BQJDBC/QueryResultTest/BQForwardOnlyResultSetFunctionTest.java
@@ -26,6 +26,7 @@ package BQJDBC.QueryResultTest;
 
 import junit.framework.Assert;
 import net.starschema.clouddb.jdbc.BQConnection;
+import net.starschema.clouddb.jdbc.BQForwardOnlyResultSet;
 import net.starschema.clouddb.jdbc.BQSupportFuncts;
 import org.apache.log4j.Logger;
 import org.junit.Before;
@@ -459,6 +460,40 @@ public class BQForwardOnlyResultSetFunctionTest {
         SimpleDateFormat dateDateFormat = new SimpleDateFormat("yyyy-MM-dd");
         Date parsedDateDate = new java.sql.Date(dateDateFormat.parse("2011-04-03").getTime());
         Assert.assertEquals(parsedDateDate, result.getObject(4));
+    }
+
+    @Test
+    public void testResultSetArraysInGetObject() throws SQLException, ParseException {
+        final String sql = "SELECT [1, 2, 3], [TIMESTAMP(\"2010-09-07 15:30:00 America/Los_Angeles\")]";
+
+        this.NewConnection(false);
+        java.sql.ResultSet result = null;
+        try {
+            Statement stmt = BQForwardOnlyResultSetFunctionTest.con
+                .createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+            stmt.setQueryTimeout(500);
+            result = stmt.executeQuery(sql);
+        } catch (SQLException e) {
+            this.logger.error("SQLException" + e.toString());
+            Assert.fail("SQLException" + e.toString());
+        }
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.next());
+
+        // for arrays, getObject() and getString() should behave identically, allowing consumers
+        // to interpret/convert types as needed
+        String expected = "[\"1\",\"2\",\"3\"]";
+        Object resultObject = result.getObject(1);
+        String resultString = result.getString(1);
+        Assert.assertEquals(expected, (String) resultObject);
+        Assert.assertEquals(expected, resultString);
+
+        // timestamp conversion should occur consumer-side for arrays
+        String expectedTwo = "[\"1.2838986E9\"]";
+        Object resultObjectTwo = result.getObject(2);
+        String resultStringTwo = result.getString(2);
+        Assert.assertEquals(expectedTwo, (String) resultObjectTwo);
+        Assert.assertEquals(expectedTwo, resultStringTwo);
     }
 
 }


### PR DESCRIPTION
Introduce new `getColumnMode(int index)` accessor on `BQResultSetMetadata` to allow consumers to determine whether results are arrays or not. 

Also change behavior to return raw string values for "REPEATED"-mode values (arrays) so that consumers can interpret/convert types as needed. 

Note that `getObject()` and `getString()` will behave identically for arrays: both will return the raw string value of the result. 