### PR TITLE
Fix sync query api path for non-US/Eu locations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,5 +154,5 @@
     </plugins>
     <finalName>${project.artifactId}-${project.version}-thin</finalName>
   </build>
-  <version>2.1.4</version>
+  <version>2.1.5</version>
 </project>

--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
@@ -51,7 +51,6 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
      * Enough time to give most fast queries time to complete, but not too long so that we worry about
      * having our socket closed by any reasonable intermediate component. */
     private static final long SYNC_TIMEOUT_MILLIS = 10 * 1000;
-    private Long maxQueryApiInitialFetchRows = null;
 
     /**
      * Constructor for BQStatement object just initializes local variables
@@ -242,18 +241,8 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
                 this.connection.getUseLegacySql(),
                 !unlimitedBillingBytes ? this.connection.getMaxBillingBytes() : null,
                 SYNC_TIMEOUT_MILLIS, // we need this to respond fast enough to avoid any socket timeouts
-                maxQueryApiInitialFetchRows != null ? maxQueryApiInitialFetchRows : (long) getMaxRows()
+                (long) getMaxRows()
         );
-    }
-
-    /**
-     *  Sets the max rows in [runSyncQuery] to something other than [getMaxRows()].
-     *  Can be zero. Can be null to unset.
-     *
-     *  Exposed for a test use case right now but in theory useful to other consumers. Not part of JDBC spec of course.
-     *  */
-    public void setQueryApiInitialFetchMaxRows(Long maxRows) {
-        this.maxQueryApiInitialFetchRows = maxRows;
     }
 
     /**

--- a/src/test/java/BQJDBC/QueryResultTest/QueryResultTest.java
+++ b/src/test/java/BQJDBC/QueryResultTest/QueryResultTest.java
@@ -26,6 +26,7 @@ package BQJDBC.QueryResultTest;
 
 import junit.framework.Assert;
 import net.starschema.clouddb.jdbc.BQConnection;
+import net.starschema.clouddb.jdbc.BQStatement;
 import net.starschema.clouddb.jdbc.BQSupportFuncts;
 import net.starschema.clouddb.jdbc.BQSupportMethods;
 import org.apache.log4j.Logger;
@@ -563,6 +564,38 @@ public class QueryResultTest {
         java.sql.ResultSet Result = null;
         try {
             Result = QueryResultTest.con.createStatement().executeQuery(sql);
+        } catch (SQLException e) {
+            this.logger.error("SQLexception" + e.toString());
+            Assert.fail("SQLException" + e.toString());
+        }
+        Assert.assertNotNull(Result);
+
+        HelperFunctions.printer(expectation);
+
+        try {
+            Assert.assertTrue(
+                    "Comparing failed in the String[][] array",
+                    this.comparer(expectation,
+                            BQSupportMethods.GetQueryResult(Result)));
+        } catch (SQLException e) {
+            this.logger.error("SQLexception" + e.toString());
+            Assert.fail(e.toString());
+        }
+    }
+
+    @Test
+    public void QueryResultTestTokyoForceFetchMoreRowsPath() {
+        final String sql = "SELECT meaning FROM tokyo_star.meaning_of_life;";
+        String[][] expectation = new String[][]{ {"42"} };
+
+        this.logger.info("Test Tokyo number: 1");
+        this.logger.info("Running query:" + sql);
+
+        java.sql.ResultSet Result = null;
+        try {
+            Statement s = QueryResultTest.con.createStatement();
+            ((BQStatement) s).setQueryApiInitialFetchMaxRows((long) 0);
+            Result = s.executeQuery(sql);
         } catch (SQLException e) {
             this.logger.error("SQLexception" + e.toString());
             Assert.fail("SQLException" + e.toString());


### PR DESCRIPTION
This path was broken for any query that did not fetch all the rows in the initial load in non-US/EU locations, because it did not call `setLocation` when getting the job.