### PR TITLE
Fixup the way the sync query code handles cancelling a job by reference

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,5 +154,5 @@
     </plugins>
     <finalName>${project.artifactId}-${project.version}-thin</finalName>
   </build>
-  <version>2.1.5</version>
+  <version>2.1.6</version>
 </project>

--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
@@ -52,9 +52,9 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
     private AtomicReference<QueryResponse> lastSyncResponse = new AtomicReference<>();
 
     /**
-     * Enough time to give most fast queries time to complete, but not too long so that we worry about
-     * having our socket closed by any reasonable intermediate component. */
-    private static final long SYNC_TIMEOUT_MILLIS = 10 * 1000;
+     * Enough time to give fast queries time to complete, but fast enough that if we want to cancel the query
+     * (for which we have to wait at least this long), we don't have to wait too long. */
+    private static final long SYNC_TIMEOUT_MILLIS = 5 * 1000;
 
     /**
      * Constructor for BQStatement object just initializes local variables

--- a/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
@@ -430,12 +430,11 @@ public class BQSupportFuncts {
     /**
      * Cancels a job. Uses the fact that it returns a JobCancelResponse to help enforce actually calling .execute().
      *
-     * @param job     Instance of Job
+     * @param jobReference  Instance of JobReference to cancel
      * @param bigquery  Instance of authorized Bigquery client
      * @param projectId The id of the Project the job is contained in
      */
-    public static JobCancelResponse cancelQuery(Job job, Bigquery bigquery, String projectId) throws IOException {
-        JobReference jobReference = job.getJobReference();
+    public static JobCancelResponse cancelQuery(JobReference jobReference, Bigquery bigquery, String projectId) throws IOException {
         return bigquery.jobs().cancel(projectId, jobReference.getJobId()).setLocation(jobReference.getLocation()).execute();
     }
 

--- a/src/test/java/BQJDBC/QueryResultTest/CancelTest.java
+++ b/src/test/java/BQJDBC/QueryResultTest/CancelTest.java
@@ -84,8 +84,6 @@ public class CancelTest {
 
     @org.junit.Test
     public void syncQueryCancel() throws SQLException, InterruptedException, IOException {
-        // Harder to check cancel worked in sync case, but it should work so long as we are sure to add the stmt
-        // to the running queries to be cancelled (which we did not in the initial impl)
         BQConnection bq = conn(true);
         TestableBQStatement stmt = new TestableBQStatement(bq.getProjectId(), bq);
         stmt.setTestPoint();


### PR DESCRIPTION
Cancel code relied on existence of a `job` on `BQStatement`, but that was only set (only could be set) by the async code. We need to wait for the sync code to time out, then cancel the query. 

Without further change here, this means that the absolute fastest a query can be cancelled is ten seconds. We can reduce the ten seconds (it's just a constant we control) but that means more queries would miss on the sync endpoint and have to poll, so it's a bit of a trade-off. For now, will reduce the sync time to five seconds in this PR. We could also enable that to be controlled by a connection parameter in the future for folks who really want to tune, but don't bother for right now because it's not clear at five seconds plus how much benefit the sync endpoint gives you anyway.