### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish package to GitHub Packages
+name: Publish Package
 on:
   push:
     branches:
@@ -8,10 +8,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Configure Git user
+        run: |
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions"
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+          server-id: github
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:
@@ -42,6 +47,6 @@ jobs:
           SERVICE_ACCOUNT_PROPERTIES: ${{ secrets.SERVICE_ACCOUNT_PROPERTIES }}
           OAUTHACCOUNT_PROPERTIES: ${{ secrets.OAUTHACCOUNT_PROPERTIES }}
       - name: Publish package
-        run: mvn -B deploy
+        run: mvn -B release:prepare release:perform
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>net.starschema.clouddb.bqjdbc</groupId>
   <artifactId>bqjdbc</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <name>Big Query over JDBC</name>
   <description>A simple JDBC driver, to reach Google's BigQuery</description>
   <properties>
@@ -16,6 +16,9 @@
       <url>https://maven.pkg.github.com/jonathanswenson/starschema-bigquery-jdbc</url>
     </repository>
   </distributionManagement>
+  <scm>
+    <developerConnection>scm:git:https://github.com/jonathanswenson/starschema-bigquery-jdbc.git</developerConnection>
+  </scm>
   <repositories>
     <repository>
       <id>google-api-services</id>


### PR DESCRIPTION
This release workflow runs through Maven's release plugin which does the
following:

## Prepare
1. Change the version in the POM from x-SNAPSHOT to a new version
2. Transform the SCM information in the POM to include the final destination of the tag
3, Commit the modified POM
4. Tag the code in the SCM with a version name
5. Bump the version in the POM to a new value y-SNAPSHOT
6. Commit the modified POM

## Perform
1. Checkout from an SCM URL with optional tag
2. Run the predefined Maven deploy goal