### PR TITLE
Make the sync response null when the query completes

### DIFF
--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
@@ -341,10 +341,15 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
         }
 
         try {
-            BQSupportFuncts.cancelQuery(jobRefToCancel, this.connection.getBigquery(), this.ProjectId.replace("__", ":").replace("_", "."));
+            performQueryCancel(jobRefToCancel);
         } catch (IOException e) {
             throw new SQLException("Failed to kill query");
         }
+    }
+
+    /** Wrap [BQSupportFuncts.cancelQuery] purely for testability purposes. */
+    protected void performQueryCancel(JobReference jobRefToCancel) throws IOException {
+        BQSupportFuncts.cancelQuery(jobRefToCancel, this.connection.getBigquery(), this.ProjectId.replace("__", ":").replace("_", "."));
     }
 
     @Override


### PR DESCRIPTION
There is some undesirable behavior where in the sync query mode, we will cancel the job on `Statement#close` even though the job is already done. BigQuery happily tells us "this job is already done" and moves on, but no point initiating an API request to BQ in the general `stmt.close` case (surely slows down queries), so let's make sure to clean up after ourselves by nulling out `syncResponseFromCurrentQuery` (and change its name so that it's more obviously something that only stays around for the current query's lifecycle).

This is ultimately a bug, in that if you don't have permission to execute a cancel, this means that the normal flow where you make a Statement, execute a query, and then close the statement throws an exception, so add a test hat we are not calling cancel at the end of a successful query run.